### PR TITLE
Feature/hjemmelside og samtykke

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ $ npm run dependencies # Starter docker-containere for wonderwall, redis og mock
 $ npm run dev # Kjører dev
 ```
 
-Da kan du nå applikasjonen med innlogging på [http://localhost:3000/personbruker](http://localhost:3000/personbruker)
+Da kan du nå applikasjonen med innlogging på [http://localhost:3000/personbruker](http://localhost:3000/personbruker). Bruk testbruker `04010100653`.
 
 > [!TIP]
 > Selve applikasjonen kjører på http://localhost:3001, men siden alle requester må routes gjennom Wonderwall som kjører på port 3000 vil det fortsatt være https://localhost:3000 som gjelder

--- a/README.md
+++ b/README.md
@@ -28,6 +28,10 @@ Da kan du nå applikasjonen med innlogging på [http://localhost:3000/personbruk
 > [!TIP]
 > Selve applikasjonen kjører på http://localhost:3001, men siden alle requester må routes gjennom Wonderwall som kjører på port 3000 vil det fortsatt være https://localhost:3000 som gjelder
 
+### Test hjemmelsside
+
+Dersom man har behov for teste hjemmelsiden som kommer ved første innlogging kan man "trekke samtykke" lokalt ved å kjøre `npm run reset_samtykke`. Ved neste innlasting vil personen ikke lenger ha sett hjemmel.
+
 ### Tilgang til NAVs npm-registry
 
 For å kunne hente @navikt-pakker via npm er du nødt til å gjøre følgende:

--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
         "lint": "next lint",
         "prettier": "prettier --check \"**/*.+(js|jsx|ts|tsx|json|yml|yaml|md|css)\"",
         "prettier:fix": "prettier --write \"**/*.+(js|jsx|ts|tsx|json|yml|yaml|md|css)\"",
-        "dependencies": "scripts/run-dependencies.sh"
+        "dependencies": "scripts/run-dependencies.sh",
+        "reset_samtykke": "curl -X POST -I http://localhost:8080/pam-cv-api/test/resett_hjemmel"
     },
     "dependencies": {
         "@navikt/aksel-icons": "^6.8.0",

--- a/scripts/start-cv-api.sh
+++ b/scripts/start-cv-api.sh
@@ -1,4 +1,4 @@
 #!/usr/bin/env bash
 
 cd ../pam-cv-api-gcp
-./gradlew runLocal
+TESTBRUKER_FNR=04010100653 TESTBRUKER_UNDER_OPPFOLGING=true ./gradlew runLocal

--- a/src/app/(minCV)/_components/hjemmelside/Hjemmelside.jsx
+++ b/src/app/(minCV)/_components/hjemmelside/Hjemmelside.jsx
@@ -1,0 +1,188 @@
+import { BodyLong, Box, Button, Heading, HStack, Link, List } from "@navikt/ds-react";
+import styles from "@/app/page.module.css";
+import HeaderPanel from "@/app/_common/components/HeaderPanel";
+import NextLink from "next/link";
+import { cvConfig } from "@/app/_common/config";
+import { useContext } from "react";
+import { PersonContext } from "@/app/_common/contexts/PersonContext";
+import { StatusEnums } from "@/app/_common/enums/fetchEnums";
+
+function HjemmelIcon() {
+    return (
+        <svg
+            style={{ marginTop: "-4.5rem", marginBottom: "4rem" }}
+            width="64"
+            height="64"
+            viewBox="0 0 64 64"
+            fill="none"
+            xmlns="http://www.w3.org/2000/svg"
+        >
+            <rect x="0.000244141" width="64" height="64" rx="32" fill="#7CDAF8" />
+            <path
+                fillRule="evenodd"
+                clipRule="evenodd"
+                d="M34.3168 20.2357C33.4056 19.3244 31.9282 19.3244 31.017 20.2357L28.9194 22.3333H20.0002C19.448 22.3333 19.0002 22.781 19.0002 23.3333V35.3333C19.0002 35.5985 19.1056 35.8529 19.2931 36.0404L26.6265 43.3737C27.4445 44.1918 28.3851 44.615 29.3222 44.6453C30.2523 44.6753 31.101 44.3135 31.7074 43.7071C32.0357 43.3787 32.2923 42.9794 32.4539 42.5345L32.6265 42.7071C33.4445 43.5251 34.3851 43.9484 35.3222 43.9786C36.2523 44.0086 37.101 43.6468 37.7074 43.0404C38.047 42.7008 38.3099 42.2851 38.4702 41.8217C39.1582 42.3469 39.908 42.6212 40.6555 42.6453C41.5856 42.6753 42.4343 42.3135 43.0407 41.7071C43.6471 41.1007 44.0089 40.252 43.9789 39.3219C43.9487 38.3848 43.5254 37.4442 42.7074 36.6262L42.4145 36.3333H44.0002C44.5525 36.3333 45.0002 35.8856 45.0002 35.3333V23.3333C45.0002 22.781 44.5525 22.3333 44.0002 22.3333H36.4145L34.3168 20.2357ZM32.7074 26.6262L40.4145 34.3333H43.0002V24.3333H36.0002C35.735 24.3333 35.4807 24.2279 35.2931 24.0404L32.9026 21.6499C32.7724 21.5197 32.5614 21.5197 32.4312 21.6499L26.0811 28L26.8217 28.7406C27.4726 29.3914 28.5279 29.3914 29.1788 28.7406L31.2931 26.6262C31.6837 26.2357 32.3168 26.2357 32.7074 26.6262ZM30.6466 41.3864C30.6352 41.0318 30.4751 40.5557 29.9598 40.0404L27.9598 38.0404C27.5693 37.6499 27.5693 37.0167 27.9598 36.6262C28.3503 36.2357 28.9835 36.2357 29.374 36.6262L34.0407 41.2929C34.556 41.8081 35.0321 41.9682 35.3867 41.9796C35.7482 41.9913 36.0662 41.8531 36.2931 41.6262C36.5201 41.3992 36.6583 41.0813 36.6466 40.7197C36.6352 40.3651 36.4751 39.889 35.9598 39.3737L31.2931 34.7071C30.9026 34.3165 30.9026 33.6834 31.2931 33.2929C31.6837 32.9023 32.3168 32.9023 32.7074 33.2929L39.374 39.9595C39.8893 40.4748 40.3654 40.6349 40.72 40.6463C41.0816 40.658 41.3995 40.5198 41.6265 40.2929C41.8534 40.0659 41.9916 39.7479 41.9799 39.3864C41.9685 39.0318 41.8084 38.5557 41.2931 38.0404L32.0002 28.7475L30.593 30.1548C29.161 31.5867 26.8394 31.5867 25.4075 30.1548L23.9598 28.7071C23.5693 28.3165 23.5693 27.6834 23.9598 27.2929L26.9194 24.3333H21.0002V34.9191L28.0407 41.9595C28.556 42.4748 29.0321 42.6349 29.3867 42.6463C29.7482 42.658 30.0662 42.5198 30.2931 42.2929C30.5201 42.0659 30.6583 41.7479 30.6466 41.3864Z"
+                fill="#23262A"
+            />
+        </svg>
+    );
+}
+
+export default function Hjemmelside() {
+    const { person, bekreftSettHjemmel } = useContext(PersonContext);
+
+    return (
+        <div>
+            <HeaderPanel title={"Slik bruker NAV CV-opplysningene"} visTag={false} />
+            <Box className={styles.main}>
+                <Box background="surface-default" padding="10" className={styles.box}>
+                    <HStack justify="center">
+                        <HjemmelIcon />
+                    </HStack>
+
+                    <BodyLong spacing>
+                        Du er registrert hos NAV. For at NAV skal gi deg arbeidsrettet oppfølging er det relevant med
+                        opplysninger om din kompetanse, erfaring og jobbønsker. Når du registrerer CV-en din blir
+                        opplysningene synlige for NAV.
+                    </BodyLong>
+                    <BodyLong spacing>
+                        Har du tidligere registrert CV hos NAV kan du oppdatere den. I tillegg kan NAV hjelpe deg med å
+                        få kontakt med arbeidsgivere.
+                    </BodyLong>
+
+                    <Heading size="small" spacing>
+                        Hva bruker NAV CV-en din til?
+                    </Heading>
+                    <BodyLong spacing>
+                        NAV bruker CV-en din for å vurdere hvilken hjelp du trenger (
+                        <Link rel="noopener noreferrer" href="https://lovdata.no/lov/2006-06-16-20/§14a">
+                            NAV-loven
+                        </Link>{" "}
+                        og{" "}
+                        <Link
+                            rel="noopener noreferrer"
+                            href="https://lovdata.no/dokument/NL/lov/2004-12-10-76?q=arbeidsmarkedsloven"
+                        >
+                            arbeidsmarkedsloven
+                        </Link>
+                        ).
+                    </BodyLong>
+
+                    <Heading size="small" spacing>
+                        Slik gjør vi det:
+                    </Heading>
+                    <List className={styles.mb6}>
+                        <List.Item className={styles.mb3}>
+                            NAV-veilederen kan gjøre et søk som automatisk finner CV-er som matcher en ledig stilling
+                            eller en jobbmesse.
+                        </List.Item>
+                        <List.Item className={styles.mb3}>
+                            Hvis NAV-veilederen vurderer at CV-en din passer til en stilling eller jobbmesse, kontakter
+                            NAV deg.
+                        </List.Item>
+                        <List.Item className={styles.mb3}>
+                            Hvis du bekrefter at du er interessert i stillingen, sender NAV CV-en din til
+                            arbeidsgiveren.
+                        </List.Item>
+                        <List.Item className={styles.mb3}>
+                            Om du er aktuell for jobben, vil arbeidsgiveren kontakte deg.
+                        </List.Item>
+                    </List>
+                    <BodyLong spacing>
+                        Du kan oppdatere og endre CV-en din når du vil.{" "}
+                        <Link rel="noopener noreferrer" href="https://lovdata.no/dokument/NL/lov/1992-12-04-126">
+                            Arkivloven
+                        </Link>
+                        pålegger oss å arkivere alle opplysninger du legger inn. Les mer om{" "}
+                        <Link
+                            rel="noopener noreferrer"
+                            href={`${cvConfig.urls.nav}/no/nav-og-samfunn/om-nav/personvern-i-arbeids-og-velferdsetaten`}
+                        >
+                            behandling av personopplysninger.
+                        </Link>
+                    </BodyLong>
+
+                    <Heading size="small" spacing>
+                        Hva kan arbeidsgivere se?
+                    </Heading>
+                    <BodyLong spacing>
+                        Hvis NAV har sendt CV-en din til en arbeidsgiver, kan arbeidsgiveren se CV-opplysningene dine.
+                    </BodyLong>
+
+                    <Heading size="small" spacing>
+                        Hva skjer hvis du ikke registrerer en CV?
+                    </Heading>
+                    <List className={styles.mb6}>
+                        <List.Item className={styles.mb3}>
+                            Du kan risikere at NAV ikke har mulighet til å gi deg oppfølgingen du trenger.
+                        </List.Item>
+                        <List.Item className={styles.mb3}>
+                            Du kan gå glipp av jobbmuligheter, fordi NAV ikke kan vurdere kompetansen din mot ledige
+                            stillinger.
+                        </List.Item>
+                        <List.Item className={styles.mb3}>
+                            Du kan risikere å miste økonomisk støtte fra NAV, for eksempel dagpenger (
+                            <Link rel="noopener noreferrer" href="https://lovdata.no/lov/1997-02-28-19/§4-5">
+                                Folketrygdloven
+                            </Link>
+                            ).
+                        </List.Item>
+                    </List>
+
+                    <Heading size="small" spacing>
+                        Utarbeide statistikk og analyser
+                    </Heading>
+                    <List className={styles.mb6}>
+                        <List.Item className={styles.mb3}>
+                            Vi bruker personopplysninger til å utarbeide statistikk og analyser (
+                            <Link
+                                rel="noopener noreferrer"
+                                href="https://lovdata.no/dokument/NL/lov/2006-06-16-20/KAPITTEL_2#%C2%A74"
+                            >
+                                NAV-loven
+                            </Link>
+                            )
+                        </List.Item>
+                    </List>
+
+                    <BodyLong spacing>
+                        Hvis du vil lese denne teksten igjen, finner du den under &#34;Deling av CV&#34; seksjonen.
+                    </BodyLong>
+
+                    {person.maaBekrefteTidligereCv && (
+                        <>
+                            <Heading size="small" spacing>
+                                Du har allerede en CV på arbeidsplassen.no
+                            </Heading>
+                            <BodyLong spacing>
+                                Da du tok i bruk tjenestene på arbeidsplassen.no, samtykket du til at NAV kunne behandle
+                                personopplysningene dine.
+                            </BodyLong>
+                            <BodyLong spacing>
+                                Nå som du har registrert deg som arbeidssøker, gjelder ikke samtykket lenger. Samtykket
+                                blir erstattet av en lovhjemmel som betyr at NAV har rett til å se opplysningene i
+                                CV-en. Derfor må du gå gjennom CV-en din og se om det er noe du vil slette eller endre
+                                før du deler med NAV.
+                            </BodyLong>
+                        </>
+                    )}
+
+                    <HStack gap={"4"} className={[styles.mb3]}>
+                        <Button
+                            variant="primary"
+                            loading={person.updateStatus === StatusEnums.PENDING}
+                            onClick={() => bekreftSettHjemmel()}
+                        >
+                            Gå til tjenesten
+                        </Button>
+                        <NextLink href={`${cvConfig.urls.nav}/minside`} passHref legacyBehavior>
+                            <Button variant="secondary" as="a">
+                                Tilbake til Min side
+                            </Button>
+                        </NextLink>
+                    </HStack>
+                </Box>
+            </Box>
+        </div>
+    );
+}

--- a/src/app/_common/components/Feilside.jsx
+++ b/src/app/_common/components/Feilside.jsx
@@ -1,0 +1,49 @@
+import { BodyLong, Box, Button, Heading, HStack, VStack } from "@navikt/ds-react";
+import NextLink from "next/link";
+import styles from "@/app/page.module.css";
+import HeaderPanel from "@/app/_common/components/HeaderPanel";
+import { cvConfig } from "@/app/_common/config";
+
+export const Feilside = ({ årsak }) => {
+    return (
+        <>
+            <HeaderPanel />
+            <HStack
+                style={{
+                    display: "flex",
+                    alignItems: "flex-start",
+                    justifyContent: "center",
+                    paddingBottom: "4rem",
+                }}
+            >
+                <Box padding="10" className={[styles.box, styles.mt3]}>
+                    <VStack>
+                        <Heading level="1" size="xlarge" className="text-center" spacing>
+                            CV er ikke tilgjengelig
+                        </Heading>
+                        <BodyLong className={["text-center", styles.mb12]}>{årsak}</BodyLong>
+
+                        <HStack gap={"4"} className={[styles.mb3]}>
+                            <NextLink href={`${cvConfig.urls.nav}/person/kontakt-oss/nb`} passHref legacyBehavior>
+                                <Button variant="primary" as="a">
+                                    Kontakt oss
+                                </Button>
+                            </NextLink>
+                            <NextLink href="javascript:history.back()" passHref legacyBehavior>
+                                <Button variant="secondary" as="a">
+                                    Gå tilbake
+                                </Button>
+                            </NextLink>
+                        </HStack>
+                    </VStack>
+                </Box>
+            </HStack>
+        </>
+    );
+};
+
+export const FeilsideTekst = Object.freeze({
+    IKKE_UNDER_OPPFØLGING:
+        "Du er ikke under arbeidsrettet oppfølging og har derfor ikke tilgang til din CV. Ønsker du å se CV-en din kan du ta kontakt med oss.",
+    FETCH_ERROR: "Det har skjedd en feil under lasting av CVen din. Vennligst prøv igjen eller kom tilbake senere.",
+});

--- a/src/app/_common/components/Feilside.jsx
+++ b/src/app/_common/components/Feilside.jsx
@@ -7,7 +7,7 @@ import { cvConfig } from "@/app/_common/config";
 export const Feilside = ({ årsak }) => {
     return (
         <>
-            <HeaderPanel />
+            <HeaderPanel visTag={false}/>
             <HStack
                 style={{
                     display: "flex",
@@ -29,11 +29,9 @@ export const Feilside = ({ årsak }) => {
                                     Kontakt oss
                                 </Button>
                             </NextLink>
-                            <NextLink href="javascript:history.back()" passHref legacyBehavior>
-                                <Button variant="secondary" as="a">
-                                    Gå tilbake
-                                </Button>
-                            </NextLink>
+                            <Button variant="secondary" as="a" onClick={() => history.back()}>
+                                Gå tilbake
+                            </Button>
                         </HStack>
                     </VStack>
                 </Box>

--- a/src/app/_common/components/Feilside.jsx
+++ b/src/app/_common/components/Feilside.jsx
@@ -7,7 +7,7 @@ import { cvConfig } from "@/app/_common/config";
 export const Feilside = ({ årsak }) => {
     return (
         <>
-            <HeaderPanel visTag={false}/>
+            <HeaderPanel visTag={false} />
             <HStack
                 style={{
                     display: "flex",

--- a/src/app/_common/components/HeaderPanel.jsx
+++ b/src/app/_common/components/HeaderPanel.jsx
@@ -1,11 +1,10 @@
 import { BodyShort, Box, Detail, Heading, Hide, HStack, Show, Tag, VStack } from "@navikt/ds-react";
 import { useContext, useEffect, useState } from "react";
-import { CvContext } from "@/app/_common/contexts/CvContext";
 import { formatterFullDato } from "@/app/_common/utils/stringUtils";
 import { StatusEnums } from "@/app/_common/enums/fetchEnums";
 import { PersonContext } from "@/app/_common/contexts/PersonContext";
 
-function HeaderPanel() {
+function HeaderPanel({ title = "Din CV", visTag = true }) {
     const { person } = useContext(PersonContext);
 
     const [navn, setNavn] = useState("");
@@ -31,11 +30,13 @@ function HeaderPanel() {
                         <VStack gap={{ xs: "3", md: "3" }}>
                             <HStack gap="6" align="center">
                                 <Heading level="1" size="large">
-                                    Din CV
+                                    {title}
                                 </Heading>
-                                <Tag size="small" variant="info-filled">
-                                    Påbegynt
-                                </Tag>
+                                {visTag && (
+                                    <Tag size="small" variant="info-filled">
+                                        Påbegynt
+                                    </Tag>
+                                )}
                             </HStack>
                             <Hide below="md">
                                 <HStack gap="4" align="center">
@@ -49,13 +50,13 @@ function HeaderPanel() {
                                     >
                                         <circle id="Ellipse 16" cx="2" cy="2" r="2" fill="#B5F1FF" />
                                     </svg>
-                                    <Detail>{`Sist endret ${sistEndret ? formatterFullDato(sistEndret) : ""}`}</Detail>
+                                    {sistEndret && <Detail>{`Sist endret ${formatterFullDato(sistEndret)}`}</Detail>}
                                 </HStack>
                             </Hide>
                             <Show below="md">
                                 <VStack gap="2">
                                     <BodyShort size="small">{navn}</BodyShort>
-                                    <Detail>{`Sist endret ${sistEndret ? formatterFullDato(sistEndret) : ""}`}</Detail>
+                                    {sistEndret && <Detail>{`Sist endret ${formatterFullDato(sistEndret)}`}</Detail>}
                                 </VStack>
                             </Show>
                         </VStack>

--- a/src/app/_common/components/MidlertidigLasteside.jsx
+++ b/src/app/_common/components/MidlertidigLasteside.jsx
@@ -1,0 +1,20 @@
+import React, { useEffect, useState } from "react";
+import { Box, Heading, Loader, VStack } from "@navikt/ds-react";
+import HeaderPanel from "@/app/_common/components/HeaderPanel";
+
+export const MidlertidigLasteside = () => {
+    return (
+        <div>
+            <HeaderPanel visTag={false} />
+
+            <Box paddingBlock="16" className="container-large min-height-100vh">
+                <VStack align="center">
+                    <Heading size="xlarge" level="1" className="visually-hidden">
+                        Laster innhold
+                    </Heading>
+                    <Loader size="2xlarge" />
+                </VStack>
+            </Box>
+        </div>
+    );
+};

--- a/src/app/_common/components/MidlertidigLasteside.jsx
+++ b/src/app/_common/components/MidlertidigLasteside.jsx
@@ -2,6 +2,7 @@ import React, { useEffect, useState } from "react";
 import { Box, Heading, Loader, VStack } from "@navikt/ds-react";
 import HeaderPanel from "@/app/_common/components/HeaderPanel";
 
+// TODO (Oscar 14.10.24) Denne er ment som en midlertidig placeholder til den ekte lastesiden blir implementert
 export const MidlertidigLasteside = () => {
     return (
         <div>

--- a/src/app/_common/config.js
+++ b/src/app/_common/config.js
@@ -14,6 +14,7 @@ const configMap = {
         urls: {
             cvApi: "http://localhost:8080/pam-cv-api/rest",
             pamOntologi: "https://pam-ontologi.intern.dev.nav.no/rest/typeahead",
+            nav: "https://www.ansatt.dev.nav.no",
         },
     },
     dev: {
@@ -28,6 +29,7 @@ const configMap = {
         urls: {
             cvApi: "http://pam-cv-api-gcp/pam-cv-api/rest",
             pamOntologi: "http://pam-ontologi/rest/typeahead",
+            nav: "https://www.ansatt.dev.nav.no",
         },
     },
     prod: {
@@ -42,6 +44,7 @@ const configMap = {
         urls: {
             cvApi: "http://pam-cv-api-gcp/pam-cv-api/rest",
             pamOntologi: "http://pam-ontologi/rest/typeahead",
+            nav: "https://www.nav.no",
         },
     },
 };

--- a/src/app/_common/contexts/AuthenticationContext.jsx
+++ b/src/app/_common/contexts/AuthenticationContext.jsx
@@ -4,7 +4,7 @@ import PropTypes from "prop-types";
 export const AuthenticationContext = React.createContext({});
 
 export const AuthenticationStatus = {
-    NOT_FETCHED: "NOT_FETCHED",
+    INITIAL: "INITIAL",
     IS_FETCHING: "IS_FETCHING",
     NOT_AUTHENTICATED: "IS_NOT_AUTHENTICATED",
     IS_AUTHENTICATED: "IS_AUTHENTICATED",
@@ -12,7 +12,7 @@ export const AuthenticationStatus = {
 };
 
 function AuthenticationProvider({ children }) {
-    const [authenticationStatus, setAuthenticationStatus] = useState(AuthenticationStatus.NOT_FETCHED);
+    const [authenticationStatus, setAuthenticationStatus] = useState(AuthenticationStatus.INITIAL);
 
     const fetchIsAuthenticated = async () => {
         setAuthenticationStatus(AuthenticationStatus.IS_FETCHING);

--- a/src/app/_common/contexts/CvContext.jsx
+++ b/src/app/_common/contexts/CvContext.jsx
@@ -1,10 +1,11 @@
 import { useContext, useEffect, useState } from "react";
 import React from "react";
-import { apiRequest } from "@/app/_common/utils/fetchUtils";
+import { getJsonRequest, isFetching, putJsonRequest } from "@/app/_common/utils/fetchUtils";
 import { AuthenticationContext, AuthenticationStatus } from "@/app/_common/contexts/AuthenticationContext";
 import { StatusEnums } from "@/app/_common/enums/fetchEnums";
+import { MidlertidigLasteside } from "@/app/_common/components/MidlertidigLasteside";
 
-const initialData = { status: StatusEnums.NOT_FETCHED, data: null, updateStatus: StatusEnums.NOT_FETCHED };
+const initialData = { fetchStatus: StatusEnums.INITIAL, data: null, updateStatus: StatusEnums.INITIAL };
 export const CvContext = React.createContext({ cv: initialData });
 
 const CvProvider = ({ children }) => {
@@ -13,11 +14,12 @@ const CvProvider = ({ children }) => {
 
     const oppdaterCvSeksjon = async (data, seksjon) => {
         const cvDto = { [seksjon]: data };
-        await apiRequest(setCv, `/personbruker/api/cv/${seksjon}`, "PUT", cvDto);
+        await putJsonRequest(setCv, `/personbruker/api/cv/${seksjon}`, cvDto);
     };
 
     useEffect(() => {
-        if (authenticationStatus === AuthenticationStatus.IS_AUTHENTICATED) apiRequest(setCv, "/personbruker/api/cv");
+        if (authenticationStatus === AuthenticationStatus.IS_AUTHENTICATED)
+            getJsonRequest(setCv, "/personbruker/api/cv");
         else if (authenticationStatus === AuthenticationStatus.NOT_AUTHENTICATED) setCv(initialData);
     }, [authenticationStatus]);
 

--- a/src/app/_common/contexts/PersonContext.jsx
+++ b/src/app/_common/contexts/PersonContext.jsx
@@ -1,28 +1,87 @@
 import { useContext, useEffect, useState } from "react";
 import React from "react";
-import { apiRequest } from "@/app/_common/utils/fetchUtils";
+import {
+    getJsonRequest,
+    fetchHasError,
+    isFetching,
+    putJsonRequest,
+    simpleApiRequest,
+} from "@/app/_common/utils/fetchUtils";
 import { AuthenticationContext, AuthenticationStatus } from "@/app/_common/contexts/AuthenticationContext";
 import { StatusEnums } from "@/app/_common/enums/fetchEnums";
+import { Feilside, FeilsideTekst } from "@/app/_common/components/Feilside";
+import { MidlertidigLasteside } from "@/app/_common/components/MidlertidigLasteside";
+import Hjemmelside from "@/app/(minCV)/_components/hjemmelside/Hjemmelside";
 
-const initialData = { fetchStatus: StatusEnums.NOT_FETCHED, data: null, updateStatus: StatusEnums.NOT_FETCHED };
+const initialData = { fetchStatus: StatusEnums.INITIAL, data: null, updateStatus: StatusEnums.INITIAL };
 export const PersonContext = React.createContext({ person: initialData });
 
 const PersonProvider = ({ children }) => {
     const { authenticationStatus } = useContext(AuthenticationContext);
     const [person, setPerson] = useState(initialData);
+    const [erUnderOppfølging, setErUnderOppfølging] = useState(false);
+    const [harSettHjemmel, setHarSettHjemmel] = useState(true);
+
+    const hentPerson = async (statusfelt) => {
+        return await getJsonRequest(setPerson, "/personbruker/api/person", statusfelt);
+    };
 
     const oppdaterPersonalia = async (data) => {
         const dataTransformator = (prevState, newData) => ({ ...prevState.data, personalia: newData });
-        await apiRequest(setPerson, `/personbruker/api/personalia`, "PUT", data, dataTransformator);
+        await putJsonRequest(setPerson, `/personbruker/api/personalia`, data, dataTransformator);
+    };
+
+    const bekreftSettHjemmel = async () => {
+        setPerson((prevState) => ({ ...prevState, updateStatus: StatusEnums.PENDING }));
+        const response = await simpleApiRequest("/personbruker/api/samtykke", "POST");
+
+        if (!response.ok) {
+            setPerson((prevState) => ({ ...prevState, updateStatus: StatusEnums.ERROR }));
+            return;
+        }
+
+        await hentPerson("updateStatus");
     };
 
     useEffect(() => {
-        if (authenticationStatus === AuthenticationStatus.IS_AUTHENTICATED)
-            apiRequest(setPerson, "/personbruker/api/person");
+        if (authenticationStatus === AuthenticationStatus.IS_AUTHENTICATED) hentPerson("fetchStatus");
         else if (authenticationStatus === AuthenticationStatus.NOT_AUTHENTICATED) setPerson(initialData);
     }, [authenticationStatus]);
 
-    return <PersonContext.Provider value={{ person, oppdaterPersonalia }}>{children}</PersonContext.Provider>;
+    useEffect(() => {
+        const oppdaterPersonContext = () => {
+            setErUnderOppfølging(person.data.erUnderOppfoelging);
+            setHarSettHjemmel(person.data.harSettHjemmelEllerSamtykket);
+        };
+
+        if (person.data) oppdaterPersonContext(person);
+    }, [person]);
+
+    console.log("harSetthjemmel:", harSettHjemmel);
+
+    const medProvider = (children) => (
+        <PersonContext.Provider value={{ person, oppdaterPersonalia, bekreftSettHjemmel }}>
+            {children}
+        </PersonContext.Provider>
+    );
+
+    if (isFetching(person)) {
+        return medProvider(<MidlertidigLasteside />);
+    }
+
+    if (fetchHasError(person)) {
+        return medProvider(<Feilside årsak={FeilsideTekst.FETCH_ERROR} />);
+    }
+
+    if (!erUnderOppfølging) {
+        return medProvider(<Feilside årsak={FeilsideTekst.IKKE_UNDER_OPPFØLGING} />);
+    }
+
+    if (!harSettHjemmel) {
+        return medProvider(<Hjemmelside />);
+    }
+
+    return medProvider(children);
 };
 
 export default PersonProvider;

--- a/src/app/_common/contexts/PersonContext.jsx
+++ b/src/app/_common/contexts/PersonContext.jsx
@@ -57,8 +57,6 @@ const PersonProvider = ({ children }) => {
         if (person.data) oppdaterPersonContext(person);
     }, [person]);
 
-    console.log("harSetthjemmel:", harSettHjemmel);
-
     const medProvider = (children) => (
         <PersonContext.Provider value={{ person, oppdaterPersonalia, bekreftSettHjemmel }}>
             {children}

--- a/src/app/_common/enums/fetchEnums.js
+++ b/src/app/_common/enums/fetchEnums.js
@@ -1,5 +1,5 @@
 export const StatusEnums = Object.freeze({
-    NOT_FETCHED: "NOT_FETCHED",
+    INITIAL: "INITIAL",
     PENDING: "PENDING",
     SUCCESS: "SUCCESS",
     ERROR: "ERROR",

--- a/src/app/_common/utils/fetchUtils.js
+++ b/src/app/_common/utils/fetchUtils.js
@@ -17,7 +17,6 @@ export const simpleApiRequest = async (url, method, body = null) => {
 };
 
 export const getJsonRequest = async (setData, url, statusfelt = null) => {
-    console.log("STATUSFELT I GETJSONREQUEST", statusfelt);
     await apiJsonRequest(setData, url, "GET", null, null, statusfelt);
 };
 

--- a/src/app/api/samtykke/route.js
+++ b/src/app/api/samtykke/route.js
@@ -1,0 +1,29 @@
+import logger from "@/app/_common/utils/logger";
+import { exchangeToken } from "@/app/_common/utils/tokenUtils";
+import { cvConfig } from "@/app/_common/config";
+
+export async function POST(request) {
+    const token = await exchangeToken(request, cvConfig.audience.cvApi);
+    const cvApiBaseUrl = cvConfig.urls.cvApi;
+    const fullUrl = `${cvApiBaseUrl}/godta-hjemmel`;
+
+    const requestHeaders = new Headers(request.headers);
+    const callId = requestHeaders.get("nav-callid");
+    requestHeaders.set("authorization", `Bearer ${token}`);
+
+    logger.info(`Godtar hjemmel mot cv-api`);
+
+    const response = await fetch(fullUrl, {
+        credentials: "same-origin",
+        method: "POST",
+        headers: requestHeaders,
+    });
+
+    if (!response.ok) {
+        logger.error(`Feil ved bekreftelse av lest hjemmel. Status code: ${response.status}. CallId: ${callId}`);
+    }
+
+    return new Response(response.body, {
+        status: response.status,
+    });
+}

--- a/src/app/layout.js
+++ b/src/app/layout.js
@@ -13,6 +13,7 @@ const RootLayout = async (props) => {
     const Decorator = await fetchDecoratorReact({
         env: cvConfig.dekoratoren.miljø,
         params: {
+            utilsBackground: "white",
             context: "privatperson",
             redirectToApp: true,
             breadcrumbs: [

--- a/src/app/page.module.css
+++ b/src/app/page.module.css
@@ -228,6 +228,10 @@
     margin-bottom: var(--a-spacing-16) !important;
 }
 
+.mt3 {
+    margin-top: var(--a-spacing-3) !important;
+}
+
 .mt6 {
     margin-top: var(--a-spacing-6) !important;
 }


### PR DESCRIPTION
Har lagt inn logikk for å reagere på om bruker er under oppføling og om de har sett hjemmelsteksten. På `cv-api`-siden har jeg også laget støtte for å sette testbruker til "under oppfølging", og et endepunkt lokalt som kan brukes til å sette "harSettHjemmel" til false. Denne nås på `npm run reset_samtykke`, men er nylig merget, så husk å pulle pam-cv-api-gcp før kjøring.

Har laget hjemmelssiden og feilsiden etter design, og lagt til en midlertidig "Laster Innhold" komponent slik at jeg kunne teste logikken. Denne må byttes ut med nye design for lasting når vi kommer så langt.

 
<img width="1384" alt="Screenshot 2024-10-14 at 09 03 21" src="https://github.com/user-attachments/assets/fa5e18fa-b1f9-4375-883c-bd82a047737c">
<img width="1378" alt="Screenshot 2024-10-14 at 09 04 33" src="https://github.com/user-attachments/assets/997ea6b3-b4ca-49a4-81e7-b85189e6aff5">
<img width="1271" alt="Screenshot 2024-10-14 at 09 04 44" src="https://github.com/user-attachments/assets/8c3a781b-e967-457f-8d99-8cde1c7ee2c2">

<img width="1283" alt="Screenshot 2024-10-14 at 09 15 44" src="https://github.com/user-attachments/assets/3369204a-a5a5-4a1c-9330-4f781c761b5f">
