### PR TITLE
Fikser opp i "blipp" etter laste-visning før modaler lukkes

### DIFF
--- a/src/app/(minCV)/_components/andreErfaringer/AndreErfaringer.jsx
+++ b/src/app/(minCV)/_components/andreErfaringer/AndreErfaringer.jsx
@@ -5,24 +5,15 @@ import { formatterDato } from "@/app/_common/utils/stringUtils";
 import { AndreErfaringerModal } from "@/app/(minCV)/_components/andreErfaringer/AndreErfaringerModal";
 import { CvSeksjonEnum, SeksjonsIdEnum } from "@/app/_common/enums/cvEnums";
 import { useCv } from "@/app/_common/hooks/swr/useCv";
+import { SeksjonSkeleton } from "@/app/_common/components/SeksjonSkeleton";
 import { useOppdaterCvSeksjon } from "@/app/_common/hooks/swr/useOppdaterCvSeksjon";
 import { useCvModal } from "@/app/_common/hooks/useCvModal";
-import { SeksjonSkeleton } from "@/app/_common/components/SeksjonSkeleton";
 
 export default function AndreErfaringer() {
     const { andreErfaringer, cvLaster } = useCv();
-    const { oppdateringOk, laster, feilet, oppdaterMedData, setVisFeilmelding } = useOppdaterCvSeksjon(
-        CvSeksjonEnum.ANDRE_ERFARINGER,
-    );
-
-    const { modalÅpen, gjeldendeElement, toggleModal, lagreElement, slettElement } = useCvModal(
-        andreErfaringer,
-        oppdaterMedData,
-        oppdateringOk,
-        laster,
-        feilet,
-        setVisFeilmelding,
-    );
+    const oppdateringprops = useOppdaterCvSeksjon(CvSeksjonEnum.ANDRE_ERFARINGER);
+    const modalProps = useCvModal(andreErfaringer, oppdateringprops);
+    const { modalÅpen, toggleModal, slettElement, laster } = modalProps;
 
     const AndreErfaringerIcon = () => (
         <svg
@@ -98,6 +89,7 @@ export default function AndreErfaringer() {
                                                 icon={<TrashIcon aria-hidden />}
                                                 variant="tertiary"
                                                 onClick={() => slettElement(index)}
+                                                loading={laster}
                                             >
                                                 Fjern
                                             </Button>
@@ -112,16 +104,7 @@ export default function AndreErfaringer() {
                     </>
                 </Box>
             )}
-            {modalÅpen && (
-                <AndreErfaringerModal
-                    modalÅpen={modalÅpen}
-                    toggleModal={toggleModal}
-                    erfaring={gjeldendeElement}
-                    lagreErfaring={lagreElement}
-                    laster={laster}
-                    feilet={feilet}
-                />
-            )}
+            {modalÅpen && <AndreErfaringerModal {...modalProps} />}
         </div>
     );
 }

--- a/src/app/(minCV)/_components/andreErfaringer/AndreErfaringerModal.jsx
+++ b/src/app/(minCV)/_components/andreErfaringer/AndreErfaringerModal.jsx
@@ -1,11 +1,10 @@
-import { BodyLong, Button, Checkbox, CheckboxGroup, Heading, HStack, Modal, TextField } from "@navikt/ds-react";
+import { BodyLong, Checkbox, CheckboxGroup, HStack, TextField } from "@navikt/ds-react";
 import styles from "@/app/page.module.css";
 import { useEffect, useState } from "react";
 import { Datovelger } from "@/app/(minCV)/_components/datovelger/Datovelger";
-import { PersonCircleIcon } from "@navikt/aksel-icons";
 import { CvModal } from "@/app/_common/components/CvModal";
 
-export const AndreErfaringerModal = ({ modalÅpen, toggleModal, erfaring, lagreErfaring, laster, feilet }) => {
+export const AndreErfaringerModal = ({ modalÅpen, toggleModal, gjeldendeElement, lagreElement, laster, feilet }) => {
     const [beskrivelse, setBeskrivelse] = useState("");
     const [rolle, setRolle] = useState("");
     const [pågår, setPågår] = useState([]);
@@ -24,8 +23,8 @@ export const AndreErfaringerModal = ({ modalÅpen, toggleModal, erfaring, lagreE
             setPågår(erfaring && erfaring.ongoing ? [true] : []);
         };
 
-        oppdaterErfaring(erfaring);
-    }, [erfaring]);
+        oppdaterErfaring(gjeldendeElement);
+    }, [gjeldendeElement]);
 
     const lagre = () => {
         const erPågående = pågår.includes(true);
@@ -35,8 +34,8 @@ export const AndreErfaringerModal = ({ modalÅpen, toggleModal, erfaring, lagreE
         if (!erPågående && !sluttdato) setSluttdatoError(true);
 
         if (rolle && startdato && (sluttdato || erPågående)) {
-            lagreErfaring({
-                ...erfaring,
+            lagreElement({
+                ...gjeldendeElement,
                 role: rolle,
                 description: beskrivelse,
                 fromDate: startdato,

--- a/src/app/(minCV)/_components/andreGodkjenninger/AndreGodkjenninger.jsx
+++ b/src/app/(minCV)/_components/andreGodkjenninger/AndreGodkjenninger.jsx
@@ -5,24 +5,15 @@ import { formatterFullDato } from "@/app/_common/utils/stringUtils";
 import AndreGodkjenningerModal from "@/app/(minCV)/_components/andreGodkjenninger/AndreGodkjenningerModal";
 import { CvSeksjonEnum, SeksjonsIdEnum } from "@/app/_common/enums/cvEnums";
 import { useCv } from "@/app/_common/hooks/swr/useCv";
+import { SeksjonSkeleton } from "@/app/_common/components/SeksjonSkeleton";
 import { useOppdaterCvSeksjon } from "@/app/_common/hooks/swr/useOppdaterCvSeksjon";
 import { useCvModal } from "@/app/_common/hooks/useCvModal";
-import { SeksjonSkeleton } from "@/app/_common/components/SeksjonSkeleton";
 
 export default function AndreGodkjenninger() {
     const { andreGodkjenninger, cvLaster } = useCv();
-    const { oppdateringOk, laster, feilet, oppdaterMedData, setVisFeilmelding } = useOppdaterCvSeksjon(
-        CvSeksjonEnum.ANDRE_GODKJENNINGER,
-    );
-
-    const { modalÅpen, gjeldendeElement, toggleModal, lagreElement, slettElement } = useCvModal(
-        andreGodkjenninger,
-        oppdaterMedData,
-        oppdateringOk,
-        laster,
-        feilet,
-        setVisFeilmelding,
-    );
+    const oppdateringprops = useOppdaterCvSeksjon(CvSeksjonEnum.ANDRE_GODKJENNINGER);
+    const modalProps = useCvModal(andreGodkjenninger, oppdateringprops);
+    const { modalÅpen, toggleModal, slettElement, laster } = modalProps;
 
     const AndreGodkjenningerIcon = () => (
         <svg
@@ -105,6 +96,7 @@ export default function AndreGodkjenninger() {
                                             icon={<TrashIcon aria-hidden />}
                                             variant="tertiary"
                                             onClick={() => slettElement(index)}
+                                            loading={laster}
                                         >
                                             Fjern
                                         </Button>
@@ -118,16 +110,7 @@ export default function AndreGodkjenninger() {
                     </Button>
                 </Box>
             )}
-            {modalÅpen && (
-                <AndreGodkjenningerModal
-                    modalÅpen={modalÅpen}
-                    toggleModal={toggleModal}
-                    godkjenning={gjeldendeElement}
-                    lagreGodkjenning={lagreElement}
-                    laster={laster}
-                    feilet={feilet}
-                />
-            )}
+            {modalÅpen && <AndreGodkjenningerModal {...modalProps} />}
         </div>
     );
 }

--- a/src/app/(minCV)/_components/andreGodkjenninger/AndreGodkjenningerModal.jsx
+++ b/src/app/(minCV)/_components/andreGodkjenninger/AndreGodkjenningerModal.jsx
@@ -1,27 +1,26 @@
-import { BodyLong, Button, Heading, HStack, Modal, TextField } from "@navikt/ds-react";
+import { BodyLong, HStack, TextField } from "@navikt/ds-react";
 import { useEffect, useState } from "react";
 import { Typeahead } from "@/app/(minCV)/_components/typeahead/Typeahead";
 import styles from "@/app/page.module.css";
 import { Datovelger } from "@/app/(minCV)/_components/datovelger/Datovelger";
 import { TypeaheadEnum } from "@/app/_common/enums/typeaheadEnums";
-import { PersonCircleIcon } from "@navikt/aksel-icons";
 import { CvModal } from "@/app/_common/components/CvModal";
 
 export default function AndreGodkjenningerModal({
     modalÅpen,
     toggleModal,
-    godkjenning,
-    lagreGodkjenning,
+    gjeldendeElement,
+    lagreElement,
     laster,
     feilet,
 }) {
-    const [valgtGodkjenning, setValgtGodkjenning] = useState(godkjenning || null);
-    const [utsteder, setUtsteder] = useState(godkjenning?.issuer || "");
+    const [valgtGodkjenning, setValgtGodkjenning] = useState(gjeldendeElement || null);
+    const [utsteder, setUtsteder] = useState(gjeldendeElement?.issuer || "");
     const [godkjenningFraDato, setGodkjenningFraDato] = useState(
-        godkjenning?.fromDate ? new Date(godkjenning.fromDate) : null,
+        gjeldendeElement?.fromDate ? new Date(gjeldendeElement.fromDate) : null,
     );
     const [godkjenningTilDato, setGodkjenningTilDato] = useState(
-        godkjenning?.toDate ? new Date(godkjenning.toDate) : null,
+        gjeldendeElement?.toDate ? new Date(gjeldendeElement.toDate) : null,
     );
     const [valgtGodkjenningError, setValgtGodkjenningError] = useState(false);
     const [godkjenningFraDatoError, setGodkjenningFraDatoError] = useState(false);
@@ -34,15 +33,15 @@ export default function AndreGodkjenningerModal({
             setGodkjenningFraDato(godkjenning?.fromDate ? new Date(godkjenning.fromDate) : null);
             setGodkjenningTilDato(godkjenning?.toDate ? new Date(godkjenning.toDate) : null);
         };
-        oppdaterGodkjenning(godkjenning || []);
-    }, [godkjenning]);
+        oppdaterGodkjenning(gjeldendeElement || []);
+    }, [gjeldendeElement]);
 
     const lagre = () => {
         if (!valgtGodkjenning || valgtGodkjenning.length === 0) setValgtGodkjenningError(true);
         if (!godkjenningFraDato) setGodkjenningFraDatoError(true);
 
         if (valgtGodkjenning && valgtGodkjenning.length !== 0 && godkjenningFraDato && !godkjenningTilDatoError) {
-            lagreGodkjenning({
+            lagreElement({
                 certificateName: valgtGodkjenning.title || valgtGodkjenning.certificateName,
                 conceptId: valgtGodkjenning.conceptId,
                 issuer: utsteder,

--- a/src/app/(minCV)/_components/arbeidsforhold/Arbeidsforhold.jsx
+++ b/src/app/(minCV)/_components/arbeidsforhold/Arbeidsforhold.jsx
@@ -6,32 +6,18 @@ import { formatterDato } from "@/app/_common/utils/stringUtils";
 import { CvSeksjonEnum, SeksjonsIdEnum } from "@/app/_common/enums/cvEnums";
 import { useHentArbeidsforhold } from "@/app/_common/hooks/swr/useHentArbeidsforhold";
 import { useCv } from "@/app/_common/hooks/swr/useCv";
-import { useOppdaterCvSeksjon } from "@/app/_common/hooks/swr/useOppdaterCvSeksjon";
-import { useCvModal } from "@/app/_common/hooks/useCvModal";
 import { SeksjonSkeleton } from "@/app/_common/components/SeksjonSkeleton";
 import parse from "html-react-parser";
 import { HentArbeidsforholdSkeleton } from "@/app/(minCV)/_components/arbeidsforhold/HentArbeidsforholdSkeleton";
+import { useOppdaterCvSeksjon } from "@/app/_common/hooks/swr/useOppdaterCvSeksjon";
+import { useCvModal } from "@/app/_common/hooks/useCvModal";
 
 export default function Arbeidsforhold() {
     const { arbeidsforhold, cvLaster } = useCv();
-    const { oppdateringOk, laster, feilet, oppdaterMedData, setVisFeilmelding } = useOppdaterCvSeksjon(
-        CvSeksjonEnum.ARBEIDSFORHOLD,
-    );
-    const { aaregManglerData, aaregLaster, setSkalHenteData } = useHentArbeidsforhold(
-        oppdaterMedData,
-        oppdateringOk,
-        laster,
-        feilet,
-    );
-
-    const { modalÅpen, gjeldendeElement, toggleModal, lagreElement, slettElement } = useCvModal(
-        arbeidsforhold,
-        oppdaterMedData,
-        oppdateringOk,
-        laster,
-        feilet,
-        setVisFeilmelding,
-    );
+    const oppdateringprops = useOppdaterCvSeksjon(CvSeksjonEnum.ARBEIDSFORHOLD);
+    const { aaregManglerData, aaregLaster, setSkalHenteData } = useHentArbeidsforhold(oppdateringprops);
+    const modalProps = useCvModal(arbeidsforhold, oppdateringprops);
+    const { modalÅpen, toggleModal, slettElement, laster } = modalProps;
 
     const arbeidsforholdManglerFelter = (arbeidsforhold) => {
         const verdiMangler = (verdi) => !verdi || verdi === "string";
@@ -160,6 +146,7 @@ export default function Arbeidsforhold() {
                                             icon={<TrashIcon aria-hidden />}
                                             variant="tertiary"
                                             onClick={() => slettElement(index)}
+                                            loading={laster}
                                         >
                                             Fjern
                                         </Button>
@@ -173,16 +160,7 @@ export default function Arbeidsforhold() {
                     )}
                 </Box>
             )}
-            {modalÅpen && (
-                <ArbeidsforholdModal
-                    modalÅpen={modalÅpen}
-                    toggleModal={toggleModal}
-                    arbeidsforhold={gjeldendeElement}
-                    lagreArbeidsforhold={lagreElement}
-                    laster={laster}
-                    feilet={feilet}
-                />
-            )}
+            {modalÅpen && <ArbeidsforholdModal {...modalProps} />}
         </div>
     );
 }

--- a/src/app/(minCV)/_components/arbeidsforhold/ArbeidsforholdModal.jsx
+++ b/src/app/(minCV)/_components/arbeidsforhold/ArbeidsforholdModal.jsx
@@ -1,15 +1,4 @@
-import {
-    BodyLong,
-    Button,
-    Checkbox,
-    CheckboxGroup,
-    Heading,
-    HStack,
-    Modal,
-    Textarea,
-    TextField,
-    VStack,
-} from "@navikt/ds-react";
+import { Checkbox, CheckboxGroup, HStack, Textarea, TextField, VStack } from "@navikt/ds-react";
 import styles from "@/app/page.module.css";
 import { useEffect, useState } from "react";
 import { Typeahead } from "@/app/(minCV)/_components/typeahead/Typeahead";
@@ -17,14 +6,7 @@ import { Datovelger } from "@/app/(minCV)/_components/datovelger/Datovelger";
 import { TypeaheadEnum } from "@/app/_common/enums/typeaheadEnums";
 import { CvModal } from "@/app/_common/components/CvModal";
 
-export const ArbeidsforholdModal = ({
-    modalÅpen,
-    toggleModal,
-    arbeidsforhold,
-    lagreArbeidsforhold,
-    laster,
-    feilet,
-}) => {
+export const ArbeidsforholdModal = ({ modalÅpen, toggleModal, gjeldendeElement, lagreElement, laster, feilet }) => {
     const [arbeidsgiver, setArbeidsgiver] = useState("");
     const [alternativTittel, setAlternativTittel] = useState("");
     const [arbeidssted, setArbeidssted] = useState("");
@@ -34,7 +16,7 @@ export const ArbeidsforholdModal = ({
     const [sluttdato, setSluttdato] = useState(null);
     const [pågår, setPågår] = useState([]);
 
-    const [stillingstittel, setStillingstittel] = useState(arbeidsforhold?.jobTitle || "");
+    const [stillingstittel, setStillingstittel] = useState(gjeldendeElement?.jobTitle || "");
     const [konseptId, setKonseptId] = useState("");
     const [styrk, setStyrk] = useState("");
 
@@ -58,8 +40,8 @@ export const ArbeidsforholdModal = ({
             setPågår(arbeidsforhold && arbeidsforhold.ongoing ? [true] : []);
         };
 
-        oppdaterArbeidsforhold(arbeidsforhold);
-    }, [arbeidsforhold]);
+        oppdaterArbeidsforhold(gjeldendeElement);
+    }, [gjeldendeElement]);
 
     const lagre = async () => {
         const erPågående = pågår.includes(true);
@@ -69,8 +51,8 @@ export const ArbeidsforholdModal = ({
         if (!erPågående && !sluttdato) setSluttdatoError(true);
 
         if (stillingstittel && startdato && (sluttdato || erPågående)) {
-            await lagreArbeidsforhold({
-                ...arbeidsforhold,
+            await lagreElement({
+                ...gjeldendeElement,
                 employer: arbeidsgiver,
                 jobTitle: stillingstittel,
                 conceptId: konseptId,

--- a/src/app/(minCV)/_components/fagbrev/Fagbrev.jsx
+++ b/src/app/(minCV)/_components/fagbrev/Fagbrev.jsx
@@ -4,24 +4,15 @@ import { PencilIcon, PlusIcon, TrashIcon } from "@navikt/aksel-icons";
 import FagbrevModal from "@/app/(minCV)/_components/fagbrev/FagbrevModal";
 import { CvSeksjonEnum, SeksjonsIdEnum } from "@/app/_common/enums/cvEnums";
 import { useCv } from "@/app/_common/hooks/swr/useCv";
+import { SeksjonSkeleton } from "@/app/_common/components/SeksjonSkeleton";
 import { useOppdaterCvSeksjon } from "@/app/_common/hooks/swr/useOppdaterCvSeksjon";
 import { useCvModal } from "@/app/_common/hooks/useCvModal";
-import { SeksjonSkeleton } from "@/app/_common/components/SeksjonSkeleton";
 
 export default function Fagbrev() {
     const { fagbrev, cvLaster } = useCv();
-    const { oppdateringOk, laster, feilet, oppdaterMedData, setVisFeilmelding } = useOppdaterCvSeksjon(
-        CvSeksjonEnum.FAGBREV,
-    );
-
-    const { modalÅpen, gjeldendeElement, toggleModal, lagreElement, slettElement } = useCvModal(
-        fagbrev,
-        oppdaterMedData,
-        oppdateringOk,
-        laster,
-        feilet,
-        setVisFeilmelding,
-    );
+    const oppdateringprops = useOppdaterCvSeksjon(CvSeksjonEnum.FAGBREV);
+    const modalProps = useCvModal(fagbrev, oppdateringprops);
+    const { modalÅpen, toggleModal, slettElement, laster } = modalProps;
 
     function FagbrevIcon() {
         return (
@@ -83,6 +74,7 @@ export default function Fagbrev() {
                                                 icon={<TrashIcon aria-hidden />}
                                                 variant="tertiary"
                                                 onClick={() => slettElement(index)}
+                                                loading={laster}
                                             >
                                                 Fjern
                                             </Button>
@@ -98,16 +90,7 @@ export default function Fagbrev() {
                     </>
                 </Box>
             )}
-            {modalÅpen && (
-                <FagbrevModal
-                    modalÅpen={modalÅpen}
-                    toggleModal={toggleModal}
-                    fagbrev={gjeldendeElement}
-                    lagreFagbrev={lagreElement}
-                    laster={laster}
-                    feilet={feilet}
-                />
-            )}
+            {modalÅpen && <FagbrevModal {...modalProps} />}
         </div>
     );
 }

--- a/src/app/(minCV)/_components/fagbrev/FagbrevModal.jsx
+++ b/src/app/(minCV)/_components/fagbrev/FagbrevModal.jsx
@@ -1,24 +1,22 @@
-import { BodyLong, Button, Heading, HStack, Modal } from "@navikt/ds-react";
 import { useEffect, useState } from "react";
 import { Typeahead } from "@/app/(minCV)/_components/typeahead/Typeahead";
 import { TypeaheadEnum } from "@/app/_common/enums/typeaheadEnums";
-import styles from "@/app/page.module.css";
 import { CvModal } from "@/app/_common/components/CvModal";
 
-export default function FagbrevModal({ modalÅpen, toggleModal, fagbrev, lagreFagbrev, laster, feilet }) {
-    const [valgtFagbrev, setValgtFagbrev] = useState(fagbrev || null);
+export default function FagbrevModal({ modalÅpen, toggleModal, gjeldendeElement, lagreElement, laster, feilet }) {
+    const [valgtFagbrev, setValgtFagbrev] = useState(gjeldendeElement || null);
     const [valgtFagbrevError, setValgtFagbrevError] = useState(false);
 
     useEffect(() => {
         const oppdaterFagbrev = (fagbrev) => setValgtFagbrev(fagbrev);
-        oppdaterFagbrev(fagbrev || []);
-    }, [fagbrev]);
+        oppdaterFagbrev(gjeldendeElement || []);
+    }, [gjeldendeElement]);
 
     const lagre = () => {
         if (!valgtFagbrev || valgtFagbrev.length === 0) setValgtFagbrevError(true);
 
         if (valgtFagbrev && valgtFagbrev.length !== 0) {
-            lagreFagbrev({
+            lagreElement({
                 title: valgtFagbrev.label || valgtFagbrev.title,
                 type: valgtFagbrev.type || valgtFagbrev.undertype === "MB" ? "MESTERBREV" : "SVENNEBREV_FAGBREV",
                 conceptId: valgtFagbrev.conceptId,

--- a/src/app/(minCV)/_components/forerkort/Forerkort.jsx
+++ b/src/app/(minCV)/_components/forerkort/Forerkort.jsx
@@ -5,24 +5,15 @@ import { formatterDato } from "@/app/_common/utils/stringUtils";
 import FørerkortModal from "@/app/(minCV)/_components/forerkort/FørerkortModal";
 import { CvSeksjonEnum, SeksjonsIdEnum } from "@/app/_common/enums/cvEnums";
 import { useCv } from "@/app/_common/hooks/swr/useCv";
+import { SeksjonSkeleton } from "@/app/_common/components/SeksjonSkeleton";
 import { useOppdaterCvSeksjon } from "@/app/_common/hooks/swr/useOppdaterCvSeksjon";
 import { useCvModal } from "@/app/_common/hooks/useCvModal";
-import { SeksjonSkeleton } from "@/app/_common/components/SeksjonSkeleton";
 
 export default function Forerkort() {
     const { førerkort, cvLaster } = useCv();
-    const { oppdateringOk, laster, feilet, oppdaterMedData, setVisFeilmelding } = useOppdaterCvSeksjon(
-        CvSeksjonEnum.FØRERKORT,
-    );
-
-    const { modalÅpen, gjeldendeElement, toggleModal, lagreElement, slettElement } = useCvModal(
-        førerkort,
-        oppdaterMedData,
-        oppdateringOk,
-        laster,
-        feilet,
-        setVisFeilmelding,
-    );
+    const oppdateringprops = useOppdaterCvSeksjon(CvSeksjonEnum.FØRERKORT);
+    const modalProps = useCvModal(førerkort, oppdateringprops);
+    const { modalÅpen, toggleModal, slettElement, laster } = modalProps;
 
     const FørerkortIcon = () => (
         <svg
@@ -88,6 +79,7 @@ export default function Forerkort() {
                                             icon={<TrashIcon aria-hidden />}
                                             variant="tertiary"
                                             onClick={() => slettElement(index)}
+                                            loading={laster}
                                         >
                                             Fjern
                                         </Button>
@@ -102,16 +94,7 @@ export default function Forerkort() {
                     </Button>
                 </Box>
             )}
-            {modalÅpen && (
-                <FørerkortModal
-                    modalÅpen={modalÅpen}
-                    toggleModal={toggleModal}
-                    førerkort={gjeldendeElement}
-                    lagreFørerkort={lagreElement}
-                    laster={laster}
-                    feilet={feilet}
-                />
-            )}
+            {modalÅpen && <FørerkortModal {...modalProps} />}
         </div>
     );
 }

--- a/src/app/(minCV)/_components/forerkort/FørerkortModal.jsx
+++ b/src/app/(minCV)/_components/forerkort/FørerkortModal.jsx
@@ -1,15 +1,19 @@
-import { BodyLong, Button, Heading, HStack, Modal, Select, VStack } from "@navikt/ds-react";
+import { BodyLong, HStack, Select, VStack } from "@navikt/ds-react";
 import { useEffect, useState } from "react";
 import styles from "@/app/page.module.css";
 import førerkortData from "@/app/_common/data/førerkort.json";
 import { Datovelger } from "@/app/(minCV)/_components/datovelger/Datovelger";
 import { CvModal } from "@/app/_common/components/CvModal";
 
-export default function FørerkortModal({ modalÅpen, toggleModal, førerkort, lagreFørerkort, laster, feilet }) {
-    const [valgtFørerkort, setValgtFørerkort] = useState(førerkort || null);
-    const [gyldigFra, setGyldigFra] = useState(førerkort?.acquiredDate ? new Date(førerkort.acquiredDate) : null);
-    const [gyldigTil, setGyldigTil] = useState(førerkort?.expiryDate ? new Date(førerkort.expiryDate) : null);
-    const [kreverDato, setKreverDato] = useState(!!førerkort?.acquiredDate);
+export default function FørerkortModal({ modalÅpen, toggleModal, gjeldendeElement, lagreElement, laster, feilet }) {
+    const [valgtFørerkort, setValgtFørerkort] = useState(gjeldendeElement || null);
+    const [gyldigFra, setGyldigFra] = useState(
+        gjeldendeElement?.acquiredDate ? new Date(gjeldendeElement.acquiredDate) : null,
+    );
+    const [gyldigTil, setGyldigTil] = useState(
+        gjeldendeElement?.expiryDate ? new Date(gjeldendeElement.expiryDate) : null,
+    );
+    const [kreverDato, setKreverDato] = useState(!!gjeldendeElement?.acquiredDate);
     const [valgtForerkortError, setValgtForerkortError] = useState(false);
     const [gyldigFraError, setGyldigFraError] = useState(false);
     const [gyldigTilError, setGyldigTilError] = useState(false);
@@ -18,8 +22,8 @@ export default function FørerkortModal({ modalÅpen, toggleModal, førerkort, l
 
     useEffect(() => {
         const oppdaterFørerkort = (førerkort) => setValgtFørerkort(førerkort);
-        oppdaterFørerkort(førerkort || []);
-    }, [førerkort]);
+        oppdaterFørerkort(gjeldendeElement || []);
+    }, [gjeldendeElement]);
 
     const velgFørerkort = (verdi) => {
         const valgtFørerkort = gyldigeFørerkort.find((e) => e.type === verdi);
@@ -34,7 +38,7 @@ export default function FørerkortModal({ modalÅpen, toggleModal, førerkort, l
         if (kreverDato && !gyldigTil) setGyldigTilError(true);
 
         if (valgtFørerkort && valgtFørerkort.length !== 0 && (kreverDato ? gyldigFra && gyldigTil : true)) {
-            lagreFørerkort({
+            lagreElement({
                 type: valgtFørerkort.label || valgtFørerkort.type,
                 acquiredDate: gyldigFra,
                 expiryDate: gyldigTil,

--- a/src/app/(minCV)/_components/jobbonsker/Jobbonsker.jsx
+++ b/src/app/(minCV)/_components/jobbonsker/Jobbonsker.jsx
@@ -12,9 +12,9 @@ import {
 import { formatterListeAvObjekterTilTekst } from "@/app/_common/utils/stringUtils";
 import { JobbonskerModal } from "@/app/(minCV)/_components/jobbonsker/JobbonskerModal";
 import { useCv } from "@/app/_common/hooks/swr/useCv";
+import { SeksjonSkeleton } from "@/app/_common/components/SeksjonSkeleton";
 import { useOppdaterCvSeksjon } from "@/app/_common/hooks/swr/useOppdaterCvSeksjon";
 import { useCvModal } from "@/app/_common/hooks/useCvModal";
-import { SeksjonSkeleton } from "@/app/_common/components/SeksjonSkeleton";
 
 function JobbonskerIcon() {
     return (
@@ -39,17 +39,10 @@ function JobbonskerIcon() {
 
 export default function Jobbonsker() {
     const { jobbønsker, cvLaster } = useCv();
-    const { oppdateringOk, laster, feilet, oppdaterMedData, setVisFeilmelding } = useOppdaterCvSeksjon(
-        CvSeksjonEnum.JOBBØNSKER,
-    );
-    const { modalÅpen, toggleModal } = useCvModal(
-        jobbønsker,
-        oppdaterMedData,
-        oppdateringOk,
-        laster,
-        feilet,
-        setVisFeilmelding,
-    );
+    const oppdateringprops = useOppdaterCvSeksjon(CvSeksjonEnum.JOBBØNSKER);
+    const modalProps = useCvModal(jobbønsker, oppdateringprops);
+    const { modalÅpen, toggleModal, laster } = modalProps;
+    const { oppdaterSeksjon } = oppdateringprops;
 
     const slettJobbønsker = async () => {
         const tommeJobbønsker = {
@@ -62,7 +55,7 @@ export default function Jobbonsker() {
             workLoadTypes: [],
             workScheduleTypes: [],
         };
-        oppdaterMedData(tommeJobbønsker);
+        oppdaterSeksjon(tommeJobbønsker);
     };
 
     const jobbønskerErTomt = () =>
@@ -138,6 +131,7 @@ export default function Jobbonsker() {
                                     icon={<TrashIcon aria-hidden />}
                                     variant="secondary"
                                     onClick={() => slettJobbønsker()}
+                                    loading={laster}
                                 >
                                     Fjern
                                 </Button>
@@ -147,14 +141,7 @@ export default function Jobbonsker() {
                 </Box>
             )}
             {modalÅpen && (
-                <JobbonskerModal
-                    toggleModal={toggleModal}
-                    modalÅpen={modalÅpen}
-                    jobbønsker={jobbønsker}
-                    lagreJobbønsker={oppdaterMedData}
-                    laster={laster}
-                    feilet={feilet}
-                />
+                <JobbonskerModal {...modalProps} lagreElement={oppdaterSeksjon} gjeldendeElement={jobbønsker} />
             )}
         </div>
     );

--- a/src/app/(minCV)/_components/jobbonsker/JobbonskerModal.jsx
+++ b/src/app/(minCV)/_components/jobbonsker/JobbonskerModal.jsx
@@ -1,15 +1,4 @@
-import {
-    BodyLong,
-    Button,
-    Checkbox,
-    CheckboxGroup,
-    Heading,
-    HStack,
-    Modal,
-    Radio,
-    RadioGroup,
-    VStack,
-} from "@navikt/ds-react";
+import { Checkbox, CheckboxGroup, HStack, Radio, RadioGroup, VStack } from "@navikt/ds-react";
 import styles from "@/app/page.module.css";
 import { AnsettelsesformEnum, ArbeidstidEnum, OmfangEnum, StarttidspunktEnum } from "@/app/_common/enums/cvEnums";
 import { useEffect, useState } from "react";
@@ -17,7 +6,7 @@ import { Typeahead } from "@/app/(minCV)/_components/typeahead/Typeahead";
 import { TypeaheadEnum } from "@/app/_common/enums/typeaheadEnums";
 import { CvModal } from "@/app/_common/components/CvModal";
 
-export const JobbonskerModal = ({ modalÅpen, toggleModal, jobbønsker, lagreJobbønsker, laster, feilet }) => {
+export const JobbonskerModal = ({ modalÅpen, toggleModal, gjeldendeElement, lagreElement, laster, feilet }) => {
     const [yrker, setYrker] = useState([]);
     const [lokasjoner, setLokasjoner] = useState([]);
     const [omfang, setOmfang] = useState([]);
@@ -37,16 +26,16 @@ export const JobbonskerModal = ({ modalÅpen, toggleModal, jobbønsker, lagreJob
             setStarttidspunkt(jobbønsker?.startOption || "ETTER_TRE_MND");
         };
 
-        oppdaterJobbønsker(jobbønsker);
-    }, [jobbønsker]);
+        oppdaterJobbønsker(gjeldendeElement);
+    }, [gjeldendeElement]);
 
     const lagre = () => {
         if (yrker.length === 0) setYrkerError(true);
         if (lokasjoner.length === 0) setLokasjonerError(true);
 
         if (yrker.length !== 0 && lokasjoner.length !== 0) {
-            lagreJobbønsker({
-                ...jobbønsker,
+            lagreElement({
+                ...gjeldendeElement,
                 occupations: yrker,
                 locations: lokasjoner,
                 workLoadTypes: omfang,

--- a/src/app/(minCV)/_components/kompetanser/Kompetanser.jsx
+++ b/src/app/(minCV)/_components/kompetanser/Kompetanser.jsx
@@ -4,24 +4,15 @@ import { PencilIcon, PlusIcon, TrashIcon } from "@navikt/aksel-icons";
 import KompetanserModal from "@/app/(minCV)/_components/kompetanser/KompetanserModal";
 import { CvSeksjonEnum, SeksjonsIdEnum } from "@/app/_common/enums/cvEnums";
 import { useCv } from "@/app/_common/hooks/swr/useCv";
+import { SeksjonSkeleton } from "@/app/_common/components/SeksjonSkeleton";
 import { useOppdaterCvSeksjon } from "@/app/_common/hooks/swr/useOppdaterCvSeksjon";
 import { useCvModal } from "@/app/_common/hooks/useCvModal";
-import { SeksjonSkeleton } from "@/app/_common/components/SeksjonSkeleton";
 
 export default function Kompetanser() {
     const { kompetanser, cvLaster } = useCv();
-    const { oppdateringOk, laster, feilet, oppdaterMedData, setVisFeilmelding } = useOppdaterCvSeksjon(
-        CvSeksjonEnum.KOMPETANSER,
-    );
-
-    const { modalÅpen, gjeldendeElement, toggleModal, lagreElement, slettElement } = useCvModal(
-        kompetanser,
-        oppdaterMedData,
-        oppdateringOk,
-        laster,
-        feilet,
-        setVisFeilmelding,
-    );
+    const oppdateringprops = useOppdaterCvSeksjon(CvSeksjonEnum.KOMPETANSER);
+    const modalProps = useCvModal(kompetanser, oppdateringprops);
+    const { modalÅpen, toggleModal, slettElement, laster } = modalProps;
 
     const KompetanserIcon = () => (
         <svg
@@ -82,6 +73,7 @@ export default function Kompetanser() {
                                                 icon={<TrashIcon aria-hidden />}
                                                 variant="tertiary"
                                                 onClick={() => slettElement(index)}
+                                                loading={laster}
                                             >
                                                 Fjern
                                             </Button>
@@ -97,16 +89,7 @@ export default function Kompetanser() {
                     </Button>
                 </Box>
             )}
-            {modalÅpen && (
-                <KompetanserModal
-                    modalÅpen={modalÅpen}
-                    toggleModal={toggleModal}
-                    kompetanse={gjeldendeElement}
-                    lagreKompetanse={lagreElement}
-                    laster={laster}
-                    feilet={feilet}
-                />
-            )}
+            {modalÅpen && <KompetanserModal {...modalProps} />}
         </div>
     );
 }

--- a/src/app/(minCV)/_components/kompetanser/KompetanserModal.jsx
+++ b/src/app/(minCV)/_components/kompetanser/KompetanserModal.jsx
@@ -1,24 +1,23 @@
-import { BodyLong, Button, Heading, HStack, Modal } from "@navikt/ds-react";
+import { BodyLong } from "@navikt/ds-react";
 import { useEffect, useState } from "react";
 import { Typeahead } from "@/app/(minCV)/_components/typeahead/Typeahead";
 import { TypeaheadEnum } from "@/app/_common/enums/typeaheadEnums";
-import styles from "@/app/page.module.css";
 import { CvModal } from "@/app/_common/components/CvModal";
 
-export default function KompetanserModal({ modalÅpen, toggleModal, kompetanse, lagreKompetanse, laster, feilet }) {
-    const [valgtKompetanse, setValgtKompetanse] = useState(kompetanse || null);
+export default function KompetanserModal({ modalÅpen, toggleModal, gjeldendeElement, lagreElement, laster, feilet }) {
+    const [valgtKompetanse, setValgtKompetanse] = useState(gjeldendeElement || null);
     const [valgtKompetanseError, setValgtKompetanseError] = useState(false);
 
     useEffect(() => {
         const oppdaterKompetanse = (kompetanse) => setValgtKompetanse(kompetanse);
-        oppdaterKompetanse(kompetanse || []);
-    }, [kompetanse]);
+        oppdaterKompetanse(gjeldendeElement || []);
+    }, [gjeldendeElement]);
 
     const lagre = () => {
         if (!valgtKompetanse || valgtKompetanse.length === 0) setValgtKompetanseError(true);
 
         if (valgtKompetanse && valgtKompetanse.length !== 0) {
-            lagreKompetanse({
+            lagreElement({
                 title: valgtKompetanse.label || valgtKompetanse.title,
                 type: valgtKompetanse.type,
                 conceptId: valgtKompetanse.conceptId,

--- a/src/app/(minCV)/_components/kurs/Kurs.jsx
+++ b/src/app/(minCV)/_components/kurs/Kurs.jsx
@@ -5,24 +5,15 @@ import { formatterFullDato, formatterTidsenhet } from "@/app/_common/utils/strin
 import KursModal from "@/app/(minCV)/_components/kurs/KursModal";
 import { CvSeksjonEnum, SeksjonsIdEnum } from "@/app/_common/enums/cvEnums";
 import { useCv } from "@/app/_common/hooks/swr/useCv";
+import { SeksjonSkeleton } from "@/app/_common/components/SeksjonSkeleton";
 import { useOppdaterCvSeksjon } from "@/app/_common/hooks/swr/useOppdaterCvSeksjon";
 import { useCvModal } from "@/app/_common/hooks/useCvModal";
-import { SeksjonSkeleton } from "@/app/_common/components/SeksjonSkeleton";
 
 export default function Kurs() {
     const { kurs, cvLaster } = useCv();
-    const { oppdateringOk, laster, feilet, oppdaterMedData, setVisFeilmelding } = useOppdaterCvSeksjon(
-        CvSeksjonEnum.KURS,
-    );
-
-    const { modalÅpen, gjeldendeElement, toggleModal, lagreElement, slettElement } = useCvModal(
-        kurs,
-        oppdaterMedData,
-        oppdateringOk,
-        laster,
-        feilet,
-        setVisFeilmelding,
-    );
+    const oppdateringprops = useOppdaterCvSeksjon(CvSeksjonEnum.KURS);
+    const modalProps = useCvModal(kurs, oppdateringprops);
+    const { modalÅpen, toggleModal, laster, slettElement } = modalProps;
 
     const KursIcon = () => (
         <svg
@@ -105,6 +96,7 @@ export default function Kurs() {
                                             icon={<TrashIcon aria-hidden />}
                                             variant="tertiary"
                                             onClick={() => slettElement(index)}
+                                            loading={laster}
                                         >
                                             Fjern
                                         </Button>
@@ -118,16 +110,7 @@ export default function Kurs() {
                     </Button>
                 </Box>
             )}
-            {modalÅpen && (
-                <KursModal
-                    modalÅpen={modalÅpen}
-                    toggleModal={toggleModal}
-                    kurs={gjeldendeElement}
-                    lagreKurs={lagreElement}
-                    laster={laster}
-                    feilet={feilet}
-                />
-            )}
+            {modalÅpen && <KursModal {...modalProps} />}
         </div>
     );
 }

--- a/src/app/(minCV)/_components/kurs/KursModal.jsx
+++ b/src/app/(minCV)/_components/kurs/KursModal.jsx
@@ -1,4 +1,4 @@
-import { BodyLong, Button, Heading, HStack, Modal, Select, TextField, VStack } from "@navikt/ds-react";
+import { BodyLong, HStack, Select, TextField, VStack } from "@navikt/ds-react";
 import { useEffect, useState } from "react";
 import styles from "@/app/page.module.css";
 import { Datovelger } from "@/app/(minCV)/_components/datovelger/Datovelger";
@@ -6,13 +6,13 @@ import { TidsenhetEnum } from "@/app/_common/enums/cvEnums";
 import { formatterTidsenhet, storForbokstav } from "@/app/_common/utils/stringUtils";
 import { CvModal } from "@/app/_common/components/CvModal";
 
-export default function KursModal({ modalÅpen, toggleModal, kurs, lagreKurs, laster, feilet }) {
-    const [valgtKurs, setValgtKurs] = useState(kurs || null);
-    const [kursnavn, setKursnavn] = useState(kurs?.title || "");
-    const [utsteder, setUtsteder] = useState(kurs?.issuer || "");
-    const [kursDato, setKursDato] = useState(kurs?.date ? new Date(kurs?.date) : null);
-    const [tidsenhet, setTidsenhet] = useState(kurs?.durationUnit || "");
-    const [lengde, setLengde] = useState(kurs?.duration || "");
+export default function KursModal({ modalÅpen, toggleModal, gjeldendeElement, lagreElement, laster, feilet }) {
+    const [valgtKurs, setValgtKurs] = useState(gjeldendeElement || null);
+    const [kursnavn, setKursnavn] = useState(gjeldendeElement?.title || "");
+    const [utsteder, setUtsteder] = useState(gjeldendeElement?.issuer || "");
+    const [kursDato, setKursDato] = useState(gjeldendeElement?.date ? new Date(gjeldendeElement?.date) : null);
+    const [tidsenhet, setTidsenhet] = useState(gjeldendeElement?.durationUnit || "");
+    const [lengde, setLengde] = useState(gjeldendeElement?.duration || "");
     const [kursnavnError, setKursnavnError] = useState(false);
     const [kursDatoError, setKursDatoError] = useState(false);
     const [lengdeError, setLengdeError] = useState(false);
@@ -26,15 +26,15 @@ export default function KursModal({ modalÅpen, toggleModal, kurs, lagreKurs, la
             setLengde(kurs?.duration || "");
             setKursDato(kurs?.date ? new Date(kurs.date) : null);
         };
-        oppdaterKurs(kurs);
-    }, [kurs]);
+        oppdaterKurs(gjeldendeElement);
+    }, [gjeldendeElement]);
 
     const lagre = async () => {
         if (!kursnavn) setKursnavnError(true);
         if (tidsenhet && !lengde) setLengdeError(true);
 
         if (kursnavn && !kursDatoError && (tidsenhet ? lengde : true)) {
-            await lagreKurs({
+            await lagreElement({
                 title: kursnavn,
                 issuer: utsteder,
                 date: kursDato,

--- a/src/app/(minCV)/_components/offentligeGodkjenninger/OffentligeGodkjenninger.jsx
+++ b/src/app/(minCV)/_components/offentligeGodkjenninger/OffentligeGodkjenninger.jsx
@@ -5,24 +5,15 @@ import { formatterFullDato } from "@/app/_common/utils/stringUtils";
 import OffentligeGodkjenningerModal from "@/app/(minCV)/_components/offentligeGodkjenninger/OffentligeGodkjenningerModal";
 import { CvSeksjonEnum, SeksjonsIdEnum } from "@/app/_common/enums/cvEnums";
 import { useCv } from "@/app/_common/hooks/swr/useCv";
+import { SeksjonSkeleton } from "@/app/_common/components/SeksjonSkeleton";
 import { useOppdaterCvSeksjon } from "@/app/_common/hooks/swr/useOppdaterCvSeksjon";
 import { useCvModal } from "@/app/_common/hooks/useCvModal";
-import { SeksjonSkeleton } from "@/app/_common/components/SeksjonSkeleton";
 
 export default function OffentligeGodkjenninger() {
     const { offentligeGodkjenninger, cvLaster } = useCv();
-    const { oppdateringOk, laster, feilet, oppdaterMedData, setVisFeilmelding } = useOppdaterCvSeksjon(
-        CvSeksjonEnum.OFFENTLIGE_GODKJENNINGER,
-    );
-
-    const { modalÅpen, gjeldendeElement, toggleModal, lagreElement, slettElement } = useCvModal(
-        offentligeGodkjenninger,
-        oppdaterMedData,
-        oppdateringOk,
-        laster,
-        feilet,
-        setVisFeilmelding,
-    );
+    const oppdateringprops = useOppdaterCvSeksjon(CvSeksjonEnum.OFFENTLIGE_GODKJENNINGER);
+    const modalProps = useCvModal(offentligeGodkjenninger, oppdateringprops);
+    const { modalÅpen, toggleModal, laster, slettElement } = modalProps;
 
     const OffentligeGodkjenningerIcon = () => (
         <svg
@@ -104,6 +95,7 @@ export default function OffentligeGodkjenninger() {
                                             icon={<TrashIcon aria-hidden />}
                                             variant="tertiary"
                                             onClick={() => slettElement(index)}
+                                            loading={laster}
                                         >
                                             Fjern
                                         </Button>
@@ -117,16 +109,7 @@ export default function OffentligeGodkjenninger() {
                     </Button>
                 </Box>
             )}
-            {modalÅpen && (
-                <OffentligeGodkjenningerModal
-                    modalÅpen={modalÅpen}
-                    toggleModal={toggleModal}
-                    godkjenning={gjeldendeElement}
-                    lagreGodkjenning={lagreElement}
-                    laster={laster}
-                    feilet={feilet}
-                />
-            )}
+            {modalÅpen && <OffentligeGodkjenningerModal {...modalProps} />}
         </div>
     );
 }

--- a/src/app/(minCV)/_components/offentligeGodkjenninger/OffentligeGodkjenningerModal.jsx
+++ b/src/app/(minCV)/_components/offentligeGodkjenninger/OffentligeGodkjenningerModal.jsx
@@ -1,4 +1,4 @@
-import { BodyLong, Button, Heading, HStack, Modal, Select, TextField } from "@navikt/ds-react";
+import { BodyLong, HStack, TextField } from "@navikt/ds-react";
 import { useEffect, useState } from "react";
 import { Typeahead } from "@/app/(minCV)/_components/typeahead/Typeahead";
 import styles from "@/app/page.module.css";
@@ -9,18 +9,18 @@ import { CvModal } from "@/app/_common/components/CvModal";
 export default function OffentligeGodkjenningerModal({
     modalÅpen,
     toggleModal,
-    godkjenning,
-    lagreGodkjenning,
+    gjeldendeElement,
+    lagreElement,
     laster,
     feilet,
 }) {
-    const [valgtGodkjenning, setValgtGodkjenning] = useState(godkjenning || null);
-    const [utsteder, setUtsteder] = useState(godkjenning?.issuer || "");
+    const [valgtGodkjenning, setValgtGodkjenning] = useState(gjeldendeElement || null);
+    const [utsteder, setUtsteder] = useState(gjeldendeElement?.issuer || "");
     const [godkjenningFraDato, setGodkjenningFraDato] = useState(
-        godkjenning?.fromDate ? new Date(godkjenning.fromDate) : null,
+        gjeldendeElement?.fromDate ? new Date(gjeldendeElement.fromDate) : null,
     );
     const [godkjenningTilDato, setGodkjenningTilDato] = useState(
-        godkjenning?.toDate ? new Date(godkjenning.toDate) : null,
+        gjeldendeElement?.toDate ? new Date(gjeldendeElement.toDate) : null,
     );
     const [valgtGodkjenningError, setValgtGodkjenningError] = useState(false);
     const [godkjenningFraDatoError, setGodkjenningFraDatoError] = useState(false);
@@ -33,15 +33,15 @@ export default function OffentligeGodkjenningerModal({
             setGodkjenningFraDato(godkjenning?.fromDate ? new Date(godkjenning.fromDate) : null);
             setGodkjenningTilDato(godkjenning?.toDate ? new Date(godkjenning.toDate) : null);
         };
-        oppdaterGodkjenning(godkjenning || []);
-    }, [godkjenning]);
+        oppdaterGodkjenning(gjeldendeElement || []);
+    }, [gjeldendeElement]);
 
     const lagre = () => {
         if (!valgtGodkjenning || valgtGodkjenning.length === 0) setValgtGodkjenningError(true);
         if (!godkjenningFraDato) setGodkjenningFraDatoError(true);
 
         if (valgtGodkjenning && valgtGodkjenning.length !== 0 && godkjenningFraDato && !godkjenningTilDatoError) {
-            lagreGodkjenning({
+            lagreElement({
                 title: valgtGodkjenning.title,
                 conceptId: valgtGodkjenning.conceptId,
                 issuer: utsteder,

--- a/src/app/(minCV)/_components/personalia/Personalia.jsx
+++ b/src/app/(minCV)/_components/personalia/Personalia.jsx
@@ -5,9 +5,9 @@ import { formatterAdresse, formatterTelefon } from "@/app/_common/utils/stringUt
 import PersonaliaModal from "@/app/(minCV)/_components/personalia/PersonaliaModal";
 import { SeksjonsIdEnum } from "@/app/_common/enums/cvEnums";
 import { usePerson } from "@/app/_common/hooks/swr/usePerson";
+import { SeksjonSkeleton } from "@/app/_common/components/SeksjonSkeleton";
 import { useOppdaterPersonalia } from "@/app/_common/hooks/swr/useOppdaterPersonalia";
 import { useCvModal } from "@/app/_common/hooks/useCvModal";
-import { SeksjonSkeleton } from "@/app/_common/components/SeksjonSkeleton";
 
 function PersonaliaIcon() {
     return (
@@ -32,16 +32,9 @@ function PersonaliaIcon() {
 
 export default function Personalia() {
     const { personalia, personLaster } = usePerson();
-    const { oppdateringOk, laster, feilet, oppdaterMedData, setVisFeilmelding } = useOppdaterPersonalia();
-
-    const { modalÅpen, toggleModal } = useCvModal(
-        personalia,
-        oppdaterMedData,
-        oppdateringOk,
-        laster,
-        feilet,
-        setVisFeilmelding,
-    );
+    const oppdateringprops = useOppdaterPersonalia();
+    const modalProps = useCvModal(personalia, oppdateringprops);
+    const { modalÅpen, toggleModal } = modalProps;
 
     return (
         <div data-section id={SeksjonsIdEnum.PERSONALIA}>
@@ -84,12 +77,9 @@ export default function Personalia() {
             )}
             {modalÅpen && (
                 <PersonaliaModal
-                    modalÅpen={modalÅpen}
-                    toggleModal={toggleModal}
-                    personalia={personalia}
-                    lagrePersonalia={oppdaterMedData}
-                    laster={laster}
-                    feilet={feilet}
+                    {...modalProps}
+                    gjeldendeElement={personalia}
+                    lagreElement={oppdateringprops.oppdaterSeksjon}
                 />
             )}
         </div>

--- a/src/app/(minCV)/_components/personalia/PersonaliaModal.jsx
+++ b/src/app/(minCV)/_components/personalia/PersonaliaModal.jsx
@@ -6,7 +6,15 @@ import { formatterFullDato } from "@/app/_common/utils/stringUtils";
 import ValidateEmail from "@/app/_common/components/ValidateEmail";
 import { CvModal } from "@/app/_common/components/CvModal";
 
-export default function PersonaliaModal({ modalÅpen, toggleModal, personalia, lagrePersonalia, laster, feilet }) {
+export default function PersonaliaModal({
+    modalÅpen,
+    toggleModal,
+    gjeldendeElement: personalia,
+    lagreElement: lagrePersonalia,
+    laster,
+    feilet,
+}) {
+    console.log(personalia);
     const [fornavn, setFornavn] = useState("");
     const [etternavn, setEtternavn] = useState("");
     const [epost, setEpost] = useState("");
@@ -139,7 +147,6 @@ export default function PersonaliaModal({ modalÅpen, toggleModal, personalia, l
                 label="Gateadresse"
                 value={adresse}
                 onChange={(e) => setAdresse(e.target.value)}
-                disabled={laster}
             />
             <HStack justify="space-between">
                 <VStack className={styles.element}>

--- a/src/app/(minCV)/_components/sammendrag/Sammendrag.jsx
+++ b/src/app/(minCV)/_components/sammendrag/Sammendrag.jsx
@@ -1,31 +1,28 @@
-import { Alert, BodyLong, Box, Button, Heading, HStack, Modal, Textarea, VStack } from "@navikt/ds-react";
+import { Alert, BodyLong, Box, Button, Heading, HStack, Textarea, VStack } from "@navikt/ds-react";
 import styles from "@/app/page.module.css";
 import { PencilIcon, PlusIcon, TrashIcon } from "@navikt/aksel-icons";
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { CvSeksjonEnum, SeksjonsIdEnum } from "@/app/_common/enums/cvEnums";
 import { useCv } from "@/app/_common/hooks/swr/useCv";
-import { useOppdaterCvSeksjon } from "@/app/_common/hooks/swr/useOppdaterCvSeksjon";
-import { useCvModal } from "@/app/_common/hooks/useCvModal";
 import { SeksjonSkeleton } from "@/app/_common/components/SeksjonSkeleton";
 import parse from "html-react-parser";
 import { CvModal } from "@/app/_common/components/CvModal";
+import { useOppdaterCvSeksjon } from "@/app/_common/hooks/swr/useOppdaterCvSeksjon";
+import { useCvModal } from "@/app/_common/hooks/useCvModal";
 
 export default function Sammendrag() {
     const { sammendrag, cvLaster } = useCv();
+    const oppdateringprops = useOppdaterCvSeksjon(CvSeksjonEnum.SAMMENDRAG);
+    const modalProps = useCvModal(sammendrag, oppdateringprops);
+    const { oppdaterSeksjon } = oppdateringprops;
+    const { modalÅpen, toggleModal, laster, feilet } = modalProps;
+
     const [sammendragEndring, setSammendragEndring] = useState(sammendrag || "");
     const [sammendragError, setSammendragError] = useState(false);
 
-    const { oppdateringOk, laster, feilet, oppdaterMedData, setVisFeilmelding } = useOppdaterCvSeksjon(
-        CvSeksjonEnum.SAMMENDRAG,
-    );
-    const { modalÅpen, toggleModal } = useCvModal(
-        sammendrag,
-        oppdaterMedData,
-        oppdateringOk,
-        laster,
-        feilet,
-        setVisFeilmelding,
-    );
+    useEffect(() => {
+        if (sammendrag) setSammendragEndring(sammendrag);
+    }, [sammendrag]);
 
     const SammendragIcon = () => (
         <svg
@@ -48,7 +45,7 @@ export default function Sammendrag() {
 
     const lagre = () => {
         if (!sammendragEndring) setSammendragError(true);
-        if (sammendragEndring) oppdaterMedData(sammendragEndring);
+        if (sammendragEndring) oppdaterSeksjon(sammendragEndring);
     };
 
     return (
@@ -97,7 +94,8 @@ export default function Sammendrag() {
                                 <Button
                                     icon={<TrashIcon aria-hidden />}
                                     variant="tertiary"
-                                    onClick={() => oppdaterMedData("")}
+                                    onClick={() => oppdaterSeksjon("")}
+                                    loading={laster}
                                 >
                                     Fjern
                                 </Button>

--- a/src/app/(minCV)/_components/sprak/Sprak.jsx
+++ b/src/app/(minCV)/_components/sprak/Sprak.jsx
@@ -4,24 +4,15 @@ import { PencilIcon, PlusIcon, TrashIcon } from "@navikt/aksel-icons";
 import { CvSeksjonEnum, SeksjonsIdEnum, SpråkEnum } from "@/app/_common/enums/cvEnums";
 import SpråkModal from "@/app/(minCV)/_components/sprak/SpråkModal";
 import { useCv } from "@/app/_common/hooks/swr/useCv";
+import { SeksjonSkeleton } from "@/app/_common/components/SeksjonSkeleton";
 import { useOppdaterCvSeksjon } from "@/app/_common/hooks/swr/useOppdaterCvSeksjon";
 import { useCvModal } from "@/app/_common/hooks/useCvModal";
-import { SeksjonSkeleton } from "@/app/_common/components/SeksjonSkeleton";
 
 export default function Sprak() {
     const { språk, cvLaster } = useCv();
-    const { oppdateringOk, laster, feilet, oppdaterMedData, setVisFeilmelding } = useOppdaterCvSeksjon(
-        CvSeksjonEnum.SPRÅK,
-    );
-
-    const { modalÅpen, gjeldendeElement, toggleModal, lagreElement, slettElement } = useCvModal(
-        språk,
-        oppdaterMedData,
-        oppdateringOk,
-        laster,
-        feilet,
-        setVisFeilmelding,
-    );
+    const oppdateringprops = useOppdaterCvSeksjon(CvSeksjonEnum.SPRÅK);
+    const modalProps = useCvModal(språk, oppdateringprops);
+    const { modalÅpen, toggleModal, laster, slettElement } = modalProps;
 
     const SpråkIcon = () => (
         <svg
@@ -99,6 +90,7 @@ export default function Sprak() {
                                                 icon={<TrashIcon aria-hidden />}
                                                 variant="tertiary"
                                                 onClick={() => slettElement(index)}
+                                                loading={laster}
                                             >
                                                 Fjern
                                             </Button>
@@ -113,16 +105,7 @@ export default function Sprak() {
                     </Button>
                 </Box>
             )}
-            {modalÅpen && (
-                <SpråkModal
-                    modalÅpen={modalÅpen}
-                    toggleModal={toggleModal}
-                    språk={gjeldendeElement}
-                    lagreSpråk={lagreElement}
-                    laster={laster}
-                    feilet={feilet}
-                />
-            )}
+            {modalÅpen && <SpråkModal {...modalProps} />}
         </div>
     );
 }

--- a/src/app/(minCV)/_components/sprak/SpråkModal.jsx
+++ b/src/app/(minCV)/_components/sprak/SpråkModal.jsx
@@ -1,4 +1,4 @@
-import { BodyLong, Button, Heading, HStack, Modal, Select } from "@navikt/ds-react";
+import { BodyLong, Select } from "@navikt/ds-react";
 import { useEffect, useState } from "react";
 import { Typeahead } from "@/app/(minCV)/_components/typeahead/Typeahead";
 import { SpråkEnum } from "@/app/_common/enums/cvEnums";
@@ -6,8 +6,8 @@ import styles from "@/app/page.module.css";
 import { TypeaheadEnum } from "@/app/_common/enums/typeaheadEnums";
 import { CvModal } from "@/app/_common/components/CvModal";
 
-export default function SpråkModal({ modalÅpen, toggleModal, språk, lagreSpråk, laster, feilet }) {
-    const [valgtSpråk, setValgtSpråk] = useState(språk || null);
+export default function SpråkModal({ modalÅpen, toggleModal, gjeldendeElement, lagreElement, laster, feilet }) {
+    const [valgtSpråk, setValgtSpråk] = useState(gjeldendeElement || null);
     const [muntligEvne, setMuntligEvne] = useState("IKKE_OPPGITT");
     const [skriftligEvne, setSkriftligEvne] = useState("IKKE_OPPGITT");
     const [valgtSprakError, setValgtSprakError] = useState(false);
@@ -18,14 +18,14 @@ export default function SpråkModal({ modalÅpen, toggleModal, språk, lagreSpr�
             setMuntligEvne(språk?.oralProficiency || "IKKE_OPPGITT");
             setSkriftligEvne(språk?.writtenProficiency || "IKKE_OPPGITT");
         };
-        oppdaterSpråk(språk || []);
-    }, [språk]);
+        oppdaterSpråk(gjeldendeElement || []);
+    }, [gjeldendeElement]);
 
     const lagre = () => {
         if (!valgtSpråk || valgtSpråk.length === 0) setValgtSprakError(true);
 
         if (valgtSpråk && valgtSpråk.length !== 0) {
-            lagreSpråk({
+            lagreElement({
                 language: valgtSpråk.language || valgtSpråk.title,
                 iso3Code: valgtSpråk.iso3Code || valgtSpråk.kode,
                 oralProficiency: muntligEvne,

--- a/src/app/(minCV)/_components/utdanninger/UtdanningModal.jsx
+++ b/src/app/(minCV)/_components/utdanninger/UtdanningModal.jsx
@@ -1,22 +1,11 @@
-import {
-    BodyLong,
-    Button,
-    Checkbox,
-    CheckboxGroup,
-    Heading,
-    HStack,
-    Modal,
-    Select,
-    Textarea,
-    TextField,
-} from "@navikt/ds-react";
+import { BodyLong, Checkbox, CheckboxGroup, HStack, Select, Textarea, TextField } from "@navikt/ds-react";
 import styles from "@/app/page.module.css";
 import { UtdanningsnivåEnum } from "@/app/_common/enums/cvEnums";
 import { useEffect, useState } from "react";
 import { Datovelger } from "@/app/(minCV)/_components/datovelger/Datovelger";
 import { CvModal } from "@/app/_common/components/CvModal";
 
-export const UtdanningModal = ({ modalÅpen, toggleModal, utdanning, lagreUtdanning, laster, feilet }) => {
+export const UtdanningModal = ({ modalÅpen, toggleModal, gjeldendeElement, lagreElement, laster, feilet }) => {
     const [utdanningsnivå, setUtdanningsnivå] = useState("");
     const [gradOgRetning, setGradOgRetning] = useState("");
     const [institusjon, setInstitusjon] = useState("");
@@ -39,8 +28,8 @@ export const UtdanningModal = ({ modalÅpen, toggleModal, utdanning, lagreUtdann
             setPågår(utdanning && utdanning.ongoing ? [true] : []);
         };
 
-        oppdaterUtdanning(utdanning);
-    }, [utdanning]);
+        oppdaterUtdanning(gjeldendeElement);
+    }, [gjeldendeElement]);
 
     const lagre = () => {
         const erPågående = pågår.includes(true);
@@ -50,8 +39,8 @@ export const UtdanningModal = ({ modalÅpen, toggleModal, utdanning, lagreUtdann
         if (!erPågående && !sluttdato) setSluttdatoError(true);
 
         if (utdanningsnivå && startdato && (sluttdato || erPågående)) {
-            lagreUtdanning({
-                ...utdanning,
+            lagreElement({
+                ...gjeldendeElement,
                 nuskode: utdanningsnivå,
                 field: gradOgRetning,
                 institution: institusjon,

--- a/src/app/(minCV)/_components/utdanninger/Utdanninger.jsx
+++ b/src/app/(minCV)/_components/utdanninger/Utdanninger.jsx
@@ -5,10 +5,10 @@ import { CvSeksjonEnum, SeksjonsIdEnum, UtdanningsnivåEnum } from "@/app/_commo
 import { formatterDato } from "@/app/_common/utils/stringUtils";
 import { UtdanningModal } from "@/app/(minCV)/_components/utdanninger/UtdanningModal";
 import { useCv } from "@/app/_common/hooks/swr/useCv";
-import { useOppdaterCvSeksjon } from "@/app/_common/hooks/swr/useOppdaterCvSeksjon";
-import { useCvModal } from "@/app/_common/hooks/useCvModal";
 import { SeksjonSkeleton } from "@/app/_common/components/SeksjonSkeleton";
 import parse from "html-react-parser";
+import { useCvModal } from "@/app/_common/hooks/useCvModal";
+import { useOppdaterCvSeksjon } from "@/app/_common/hooks/swr/useOppdaterCvSeksjon";
 
 function UtdanningerIcon() {
     return (
@@ -33,18 +33,9 @@ function UtdanningerIcon() {
 
 export default function Utdanninger() {
     const { utdanninger, cvLaster } = useCv();
-    const { oppdateringOk, laster, feilet, oppdaterMedData, setVisFeilmelding } = useOppdaterCvSeksjon(
-        CvSeksjonEnum.UTDANNING,
-    );
-
-    const { modalÅpen, gjeldendeElement, toggleModal, lagreElement, slettElement } = useCvModal(
-        utdanninger,
-        oppdaterMedData,
-        oppdateringOk,
-        laster,
-        feilet,
-        setVisFeilmelding,
-    );
+    const oppdateringprops = useOppdaterCvSeksjon(CvSeksjonEnum.UTDANNING);
+    const modalProps = useCvModal(utdanninger, oppdateringprops);
+    const { modalÅpen, toggleModal, slettElement, laster } = modalProps;
 
     return (
         <div data-section id={SeksjonsIdEnum.UTDANNING}>
@@ -118,6 +109,7 @@ export default function Utdanninger() {
                                             icon={<TrashIcon aria-hidden />}
                                             variant="tertiary"
                                             onClick={() => slettElement(index)}
+                                            loading={laster}
                                         >
                                             Fjern
                                         </Button>
@@ -131,16 +123,7 @@ export default function Utdanninger() {
                     </Button>
                 </Box>
             )}
-            {modalÅpen && (
-                <UtdanningModal
-                    modalÅpen={modalÅpen}
-                    toggleModal={toggleModal}
-                    utdanning={gjeldendeElement}
-                    lagreUtdanning={lagreElement}
-                    laster={laster}
-                    feilet={feilet}
-                />
-            )}
+            {modalÅpen && <UtdanningModal {...modalProps} />}
         </div>
     );
 }

--- a/src/app/_common/hooks/swr/useHentArbeidsforhold.js
+++ b/src/app/_common/hooks/swr/useHentArbeidsforhold.js
@@ -5,19 +5,24 @@ import { simpleApiRequest } from "@/app/_common/utils/fetchUtils";
 import { useContext, useEffect, useState } from "react";
 import { ApplicationContext } from "@/app/_common/contexts/ApplicationContext";
 
-export const useHentArbeidsforhold = (
-    oppdaterArbeidsforhold,
+export const useHentArbeidsforhold = ({
+    oppdaterSeksjon: oppdaterArbeidsforhold,
     oppdateringSuksess,
     oppdateringLaster,
     oppdateringHarFeil,
-) => {
+}) => {
     const { suksessNotifikasjon, errorNotifikasjon } = useContext(ApplicationContext);
     const [skalHenteData, setSkalHenteData] = useState(false);
     const [aaregManglerData, setAaregManglerData] = useState(false);
+    const [skalViseSkeleton, setSkalViseSkeleton] = useState(false);
 
     useEffect(() => {
         if (oppdateringSuksess || oppdateringHarFeil) oppdaterArbeidsforhold(null);
     }, [oppdateringSuksess, oppdateringHarFeil]);
+
+    useEffect(() => {
+        if (oppdateringLaster === false) setSkalViseSkeleton(false);
+    }, [oppdateringLaster]);
 
     const fetcher = async (url) => {
         const response = await simpleApiRequest(url, "GET");
@@ -33,7 +38,9 @@ export const useHentArbeidsforhold = (
 
         if (data?.length === 0) {
             setAaregManglerData(true);
+            setSkalViseSkeleton(false);
         } else {
+            setSkalViseSkeleton(true);
             oppdaterArbeidsforhold(data);
         }
 
@@ -47,7 +54,7 @@ export const useHentArbeidsforhold = (
     return {
         aaregSuksess: !!data && !error,
         aaregManglerData: aaregManglerData,
-        aaregLaster: isLoading || (data && oppdateringLaster),
+        aaregLaster: isLoading || (skalViseSkeleton && oppdateringLaster),
         aaregHarFeil: error,
         setSkalHenteData,
     };

--- a/src/app/_common/hooks/swr/useOppdaterCvSeksjon.js
+++ b/src/app/_common/hooks/swr/useOppdaterCvSeksjon.js
@@ -8,7 +8,7 @@ import { ApplicationContext } from "@/app/_common/contexts/ApplicationContext";
 
 export const useOppdaterCvSeksjon = (seksjon) => {
     const { suksessNotifikasjon, errorNotifikasjon } = useContext(ApplicationContext);
-    const [dataForOppdatering, oppdaterMedData] = useState(null);
+    const [dataForOppdatering, oppdaterSeksjon] = useState(null);
     const [visFeilmelding, setVisFeilmelding] = useState(false);
 
     const fetcher = async ({ url, seksjon, body }) => {
@@ -34,10 +34,10 @@ export const useOppdaterCvSeksjon = (seksjon) => {
 
     const { data, error, isLoading } = useSWR(skalOppdatere ? { url, seksjon, body } : null, fetcher);
     return {
-        oppdateringOk: data,
-        laster: isLoading,
-        feilet: visFeilmelding || error,
-        oppdaterMedData,
+        oppdateringSuksess: data,
+        oppdateringLaster: isLoading,
+        oppdateringHarFeil: visFeilmelding || error,
+        oppdaterSeksjon,
         setVisFeilmelding,
     };
 };

--- a/src/app/_common/hooks/swr/useOppdaterPersonalia.js
+++ b/src/app/_common/hooks/swr/useOppdaterPersonalia.js
@@ -8,7 +8,7 @@ import { ApplicationContext } from "@/app/_common/contexts/ApplicationContext";
 
 export const useOppdaterPersonalia = () => {
     const { suksessNotifikasjon, errorNotifikasjon } = useContext(ApplicationContext);
-    const [dataForOppdatering, oppdaterMedData] = useState(null);
+    const [dataForOppdatering, oppdaterSeksjon] = useState(null);
     const [visFeilmelding, setVisFeilmelding] = useState(false);
 
     const { person } = usePerson();
@@ -36,10 +36,10 @@ export const useOppdaterPersonalia = () => {
     const { data, error, isLoading } = useSWR(skalOppdatere ? { url, body: dataForOppdatering } : null, fetcher);
 
     return {
-        oppdateringOk: data,
-        laster: isLoading,
-        feilet: visFeilmelding || error,
-        oppdaterMedData,
+        oppdateringSuksess: data,
+        oppdateringLaster: isLoading,
+        oppdateringHarFeil: visFeilmelding || error,
+        oppdaterSeksjon,
         setVisFeilmelding,
     };
 };

--- a/src/app/_common/hooks/useCvModal.js
+++ b/src/app/_common/hooks/useCvModal.js
@@ -2,15 +2,12 @@ import { useEffect, useState } from "react";
 
 export const useCvModal = (
     eksisterendeElementer,
-    oppdaterSeksjon,
-    oppdateringSuksess,
-    oppdateringLaster,
-    oppdateringHarFeil,
-    setVisFeilmelding,
+    { oppdaterSeksjon, oppdateringSuksess, oppdateringLaster, oppdateringHarFeil, setVisFeilmelding },
 ) => {
     const [modalÅpen, setModalÅpen] = useState(false);
     const [gjeldendeIndex, setGjeldendeIndex] = useState(-1);
     const [gjeldendeElement, setGjeldendeElement] = useState(null);
+    const [laster, setLaster] = useState(false);
 
     useEffect(() => {
         setGjeldendeElement(gjeldendeIndex >= 0 ? eksisterendeElementer[gjeldendeIndex] : null);
@@ -18,13 +15,16 @@ export const useCvModal = (
 
     useEffect(() => {
         if (oppdateringSuksess || oppdateringHarFeil) oppdaterSeksjon(null);
+        if (oppdateringHarFeil) setLaster(false);
         if (oppdateringSuksess && !oppdateringLaster && !oppdateringHarFeil) toggleModal(false);
+        if (oppdateringLaster) setLaster(true);
     }, [oppdateringSuksess, oppdateringLaster, oppdateringHarFeil]);
 
     const toggleModal = (åpen, index) => {
         setGjeldendeIndex(index >= 0 ? index : -1);
         setVisFeilmelding(false);
         setModalÅpen(åpen);
+        if (!åpen) setLaster(false);
     };
 
     const lagreElement = (oppdatertElement) => {
@@ -40,5 +40,13 @@ export const useCvModal = (
         oppdaterSeksjon(oppdaterteElementer);
     };
 
-    return { modalÅpen, gjeldendeElement, toggleModal, lagreElement, slettElement };
+    return {
+        modalÅpen,
+        gjeldendeElement,
+        toggleModal,
+        lagreElement,
+        slettElement,
+        laster,
+        feilet: oppdateringHarFeil,
+    };
 };


### PR DESCRIPTION
Fikser problem hvor laste-viewet forsvinner i et millisekund før modaler lukkes.

Har i den forbindelse måttet ta høyde for litt mer i useCvModal, så jeg har gjort endringer i samhandlingen mellom `useOppdaterCvSeksjon` og `useCvModal` hooksene. 

Siden de vanlige komponentene da ikke lenger trenger å vite noe særlig om variablene som `useOppdaterCvSeksjon` generer, har jeg "gjemt" det og sendt alle variablene videre som objekt, og kun destrukturert der variablene brukes. 