### PR TITLE
Fikser bug med validering av pågår for datoer

### DIFF
--- a/src/app/(minCV)/_components/andreErfaringer/AndreErfaringerModal.jsx
+++ b/src/app/(minCV)/_components/andreErfaringer/AndreErfaringerModal.jsx
@@ -27,7 +27,7 @@ export function AndreErfaringerModal({ modalÅpen, toggleModal, gjeldendeElement
     }, [gjeldendeElement]);
 
     const lagre = () => {
-        const erPågående = pågår.includes(true);
+        const erPågående = pågår.includes("true");
 
         if (!rolle) setRolleError(true);
         if (!startdato) setStartdatoError(true);

--- a/src/app/(minCV)/_components/arbeidsforhold/ArbeidsforholdModal.jsx
+++ b/src/app/(minCV)/_components/arbeidsforhold/ArbeidsforholdModal.jsx
@@ -44,7 +44,7 @@ export function ArbeidsforholdModal({ modalÅpen, toggleModal, gjeldendeElement,
     }, [gjeldendeElement]);
 
     const lagre = async () => {
-        const erPågående = pågår.includes(true);
+        const erPågående = pågår.includes("true");
 
         if (!stillingstittel) setStillingstittelError(true);
         if (!startdato) setStartdatoError(true);

--- a/src/app/(minCV)/_components/utdanninger/UtdanningModal.jsx
+++ b/src/app/(minCV)/_components/utdanninger/UtdanningModal.jsx
@@ -32,7 +32,7 @@ export function UtdanningModal({ modalÅpen, toggleModal, gjeldendeElement, lagr
     }, [gjeldendeElement]);
 
     const lagre = () => {
-        const erPågående = pågår.includes(true);
+        const erPågående = pågår.includes("true");
 
         if (!utdanningsnivå) setUtdanningsnivaError(true);
         if (!startdato) setStartdatoError(true);


### PR DESCRIPTION
Siden pågår er en satt av en checkbox, er verdien en string, ikke en boolean.