### PR TITLE
Legger inn mulighet for å skru av secure cookies i wonderwall for testing mot safari

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,3 +52,11 @@ For å kunne hente @navikt-pakker via npm er du nødt til å gjøre følgende:
 
 > [!CAUTION]
 > Ikke sjekk inn `.npmrc` til GitHub.
+
+### Teste i safari
+
+Safari har strengere regler enn andre browsere for å sette cookies for localhost, og derfor fungerer vanligvis ikke wonderwall med Safari. Dersom man vil teste i safari må man gå inn i `docker-compose.yml` og fjerne "#" fremst i linja
+
+```
+# --cookie.secure=false # Fjern '#' på denne linjen for å kunne bruke wonderwall i safari
+```

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -27,6 +27,7 @@ services:
       --redis.tls=false
       --redis.address=redis:6379
       --log-format=text
+      # --cookie.secure=false # Fjern '#' på denne linjen for å kunne bruke wonderwall i safari
     restart: on-failure
     environment:
       WONDERWALL_OPENID_CLIENT_JWK: >


### PR DESCRIPTION
Før du kjører `npm run setup_dependencies` må du passe på å pulle nyeste wonderwall-imaget med `docker image pull ghcr.io/nais/wonderwall:latest`.