### PR TITLE
Legger til flere feilmeldingstyper på datovelger

### DIFF
--- a/src/app/(minCV)/_components/andreErfaringer/AndreErfaringerModal.jsx
+++ b/src/app/(minCV)/_components/andreErfaringer/AndreErfaringerModal.jsx
@@ -1,4 +1,4 @@
-import { BodyShort, Checkbox, CheckboxGroup, HStack, TextField } from "@navikt/ds-react";
+import { BodyShort, Checkbox, CheckboxGroup, HStack, TextField, VStack } from "@navikt/ds-react";
 import styles from "@/app/page.module.css";
 import { useEffect, useState } from "react";
 import { Datovelger } from "@/app/(minCV)/_components/datovelger/Datovelger";
@@ -10,9 +10,16 @@ export function AndreErfaringerModal({ modalÅpen, toggleModal, gjeldendeElement
     const [pågår, setPågår] = useState([]);
     const [startdato, setStartdato] = useState(null);
     const [sluttdato, setSluttdato] = useState(null);
+
     const [rolleError, setRolleError] = useState(false);
     const [startdatoError, setStartdatoError] = useState(false);
+    const [startdatoIsAfterError, setStartdatoIsAfterError] = useState(false);
+    const [startdatoIsValidDateError, setStartdatoIsValidDateError] = useState(false);
     const [sluttdatoError, setSluttdatoError] = useState(false);
+    const [sluttdatoIsAfterError, setSluttdatoIsAfterError] = useState(false);
+    const [sluttdatoIsValidDateError, setSluttdatoIsValidDateError] = useState(false);
+
+    const [isLagre, setIsLagre] = useState(false);
 
     useEffect(() => {
         const oppdaterErfaring = (erfaring) => {
@@ -27,13 +34,22 @@ export function AndreErfaringerModal({ modalÅpen, toggleModal, gjeldendeElement
     }, [gjeldendeElement]);
 
     const lagre = () => {
+        setIsLagre(true);
         const erPågående = pågår.includes("true");
 
         if (!rolle) setRolleError(true);
         if (!startdato) setStartdatoError(true);
         if (!erPågående && !sluttdato) setSluttdatoError(true);
 
-        if (rolle && startdato && (sluttdato || erPågående)) {
+        if (
+            rolle &&
+            startdato &&
+            (sluttdato || erPågående) &&
+            !startdatoIsAfterError &&
+            !startdatoIsValidDateError &&
+            !sluttdatoIsAfterError &&
+            !sluttdatoIsValidDateError
+        ) {
             lagreElement({
                 ...gjeldendeElement,
                 role: rolle,
@@ -85,20 +101,42 @@ export function AndreErfaringerModal({ modalÅpen, toggleModal, gjeldendeElement
                 <Datovelger
                     valgtDato={startdato}
                     oppdaterDato={setStartdato}
-                    label="Fra dato"
+                    label={
+                        <VStack>
+                            <BodyShort weight="semibold">Fra dato</BodyShort>
+                            <BodyShort className={styles.mandatoryColor}>Må fylles ut</BodyShort>
+                        </VStack>
+                    }
                     obligatorisk
-                    error={startdatoError}
-                    setError={setStartdatoError}
+                    isEmptyError={startdatoError}
+                    setIsEmptyError={setStartdatoError}
+                    isAfterError={startdatoIsAfterError}
+                    setIsAfterError={setStartdatoIsAfterError}
+                    isValidDateError={startdatoIsValidDateError}
+                    setIsValidDateError={setStartdatoIsValidDateError}
+                    isLagre={isLagre}
+                    setIsLagre={setIsLagre}
                 />
 
                 {!pågår.includes("true") && (
                     <Datovelger
                         valgtDato={sluttdato}
                         oppdaterDato={setSluttdato}
-                        label="Til dato"
+                        label={
+                            <VStack>
+                                <BodyShort weight="semibold">Til dato</BodyShort>
+                                <BodyShort className={styles.mandatoryColor}>Må fylles ut</BodyShort>
+                            </VStack>
+                        }
                         obligatorisk
-                        error={sluttdatoError}
-                        setError={setSluttdatoError}
+                        isEmptyError={sluttdatoError}
+                        setIsEmptyError={setSluttdatoError}
+                        isAfterError={sluttdatoIsAfterError}
+                        setIsAfterError={setSluttdatoIsAfterError}
+                        isValidDateError={sluttdatoIsValidDateError}
+                        setIsValidDateError={setSluttdatoIsValidDateError}
+                        isLagre={isLagre}
+                        setIsLagre={setIsLagre}
                     />
                 )}
             </HStack>

--- a/src/app/(minCV)/_components/andreErfaringer/AndreErfaringerModal.jsx
+++ b/src/app/(minCV)/_components/andreErfaringer/AndreErfaringerModal.jsx
@@ -19,7 +19,8 @@ export function AndreErfaringerModal({ modalÅpen, toggleModal, gjeldendeElement
     const [sluttdatoIsAfterError, setSluttdatoIsAfterError] = useState(false);
     const [sluttdatoIsValidDateError, setSluttdatoIsValidDateError] = useState(false);
 
-    const [isLagre, setIsLagre] = useState(false);
+    const [isLagreStartdato, setIsLagreStartdato] = useState(false);
+    const [isLagreSluttdato, setIsLagreSluttdato] = useState(false);
 
     useEffect(() => {
         const oppdaterErfaring = (erfaring) => {
@@ -34,7 +35,9 @@ export function AndreErfaringerModal({ modalÅpen, toggleModal, gjeldendeElement
     }, [gjeldendeElement]);
 
     const lagre = () => {
-        setIsLagre(true);
+        setIsLagreStartdato(true);
+        setIsLagreSluttdato(true);
+
         const erPågående = pågår.includes("true");
 
         if (!rolle) setRolleError(true);
@@ -114,8 +117,8 @@ export function AndreErfaringerModal({ modalÅpen, toggleModal, gjeldendeElement
                     setIsAfterError={setStartdatoIsAfterError}
                     isValidDateError={startdatoIsValidDateError}
                     setIsValidDateError={setStartdatoIsValidDateError}
-                    isLagre={isLagre}
-                    setIsLagre={setIsLagre}
+                    isLagre={isLagreStartdato}
+                    setIsLagre={setIsLagreStartdato}
                 />
 
                 {!pågår.includes("true") && (
@@ -135,8 +138,8 @@ export function AndreErfaringerModal({ modalÅpen, toggleModal, gjeldendeElement
                         setIsAfterError={setSluttdatoIsAfterError}
                         isValidDateError={sluttdatoIsValidDateError}
                         setIsValidDateError={setSluttdatoIsValidDateError}
-                        isLagre={isLagre}
-                        setIsLagre={setIsLagre}
+                        isLagre={isLagreSluttdato}
+                        setIsLagre={setIsLagreSluttdato}
                     />
                 )}
             </HStack>

--- a/src/app/(minCV)/_components/andreGodkjenninger/AndreGodkjenningerModal.jsx
+++ b/src/app/(minCV)/_components/andreGodkjenninger/AndreGodkjenningerModal.jsx
@@ -24,7 +24,13 @@ export default function AndreGodkjenningerModal({
     );
     const [valgtGodkjenningError, setValgtGodkjenningError] = useState(false);
     const [godkjenningFraDatoError, setGodkjenningFraDatoError] = useState(false);
+    const [fraDatoIsAfterError, setFraDatoIsAfterError] = useState(false);
+    const [fraDatoIsValidDateError, setFraDatoIsValidDateError] = useState(false);
     const [godkjenningTilDatoError, setGodkjenningTilDatoError] = useState(false);
+    const [tilDatoIsAfterError, setTilDatoIsAfterError] = useState(false);
+    const [tilDatoIsValidDateError, setTilDatoIsValidDateError] = useState(false);
+
+    const [isLagre, setIsLagre] = useState(false);
 
     useEffect(() => {
         const oppdaterGodkjenning = (godkjenning) => {
@@ -37,10 +43,20 @@ export default function AndreGodkjenningerModal({
     }, [gjeldendeElement]);
 
     const lagre = () => {
+        setIsLagre(true);
         if (!valgtGodkjenning || valgtGodkjenning.length === 0) setValgtGodkjenningError(true);
         if (!godkjenningFraDato) setGodkjenningFraDatoError(true);
 
-        if (valgtGodkjenning && valgtGodkjenning.length !== 0 && godkjenningFraDato && !godkjenningTilDatoError) {
+        if (
+            valgtGodkjenning &&
+            valgtGodkjenning.length !== 0 &&
+            godkjenningFraDato &&
+            !fraDatoIsAfterError &&
+            !fraDatoIsValidDateError &&
+            !godkjenningTilDatoError &&
+            !tilDatoIsAfterError &&
+            !tilDatoIsValidDateError
+        ) {
             lagreElement({
                 certificateName: valgtGodkjenning.title || valgtGodkjenning.certificateName,
                 conceptId: valgtGodkjenning.conceptId,
@@ -97,16 +113,29 @@ export default function AndreGodkjenningerModal({
                             <BodyShort className={styles.mandatoryColor}>Må fylles ut</BodyShort>
                         </HStack>
                     }
-                    error={godkjenningFraDatoError}
-                    setError={setGodkjenningFraDatoError}
+                    obligatorisk
+                    isEmptyError={godkjenningFraDatoError}
+                    setIsEmptyError={setGodkjenningFraDatoError}
+                    isAfterError={fraDatoIsAfterError}
+                    setIsAfterError={setFraDatoIsAfterError}
+                    isValidDateError={fraDatoIsValidDateError}
+                    setIsValidDateError={setFraDatoIsValidDateError}
+                    isLagre={isLagre}
+                    setIsLagre={setIsLagre}
                 />
                 <Datovelger
                     valgtDato={godkjenningTilDato}
                     oppdaterDato={setGodkjenningTilDato}
                     label="Utløper"
                     fremtid
-                    error={godkjenningTilDatoError}
-                    setError={setGodkjenningTilDatoError}
+                    isEmptyError={godkjenningTilDatoError}
+                    setIsEmptyError={setGodkjenningTilDatoError}
+                    isAfterError={tilDatoIsAfterError}
+                    setIsAfterError={setTilDatoIsAfterError}
+                    isValidDateError={tilDatoIsValidDateError}
+                    setIsValidDateError={setTilDatoIsValidDateError}
+                    isLagre={isLagre}
+                    setIsLagre={setIsLagre}
                 />
             </HStack>
         </CvModalForm>

--- a/src/app/(minCV)/_components/andreGodkjenninger/AndreGodkjenningerModal.jsx
+++ b/src/app/(minCV)/_components/andreGodkjenninger/AndreGodkjenningerModal.jsx
@@ -30,7 +30,8 @@ export default function AndreGodkjenningerModal({
     const [tilDatoIsAfterError, setTilDatoIsAfterError] = useState(false);
     const [tilDatoIsValidDateError, setTilDatoIsValidDateError] = useState(false);
 
-    const [isLagre, setIsLagre] = useState(false);
+    const [isLagreFraDato, setIsLagreFraDato] = useState(false);
+    const [isLagreTilDato, setIsLagreTilDato] = useState(false);
 
     useEffect(() => {
         const oppdaterGodkjenning = (godkjenning) => {
@@ -43,7 +44,9 @@ export default function AndreGodkjenningerModal({
     }, [gjeldendeElement]);
 
     const lagre = () => {
-        setIsLagre(true);
+        setIsLagreFraDato(true);
+        setIsLagreTilDato(true);
+
         if (!valgtGodkjenning || valgtGodkjenning.length === 0) setValgtGodkjenningError(true);
         if (!godkjenningFraDato) setGodkjenningFraDatoError(true);
 
@@ -120,8 +123,8 @@ export default function AndreGodkjenningerModal({
                     setIsAfterError={setFraDatoIsAfterError}
                     isValidDateError={fraDatoIsValidDateError}
                     setIsValidDateError={setFraDatoIsValidDateError}
-                    isLagre={isLagre}
-                    setIsLagre={setIsLagre}
+                    isLagre={isLagreFraDato}
+                    setIsLagre={setIsLagreFraDato}
                 />
                 <Datovelger
                     valgtDato={godkjenningTilDato}
@@ -134,8 +137,8 @@ export default function AndreGodkjenningerModal({
                     setIsAfterError={setTilDatoIsAfterError}
                     isValidDateError={tilDatoIsValidDateError}
                     setIsValidDateError={setTilDatoIsValidDateError}
-                    isLagre={isLagre}
-                    setIsLagre={setIsLagre}
+                    isLagre={isLagreTilDato}
+                    setIsLagre={setIsLagreTilDato}
                 />
             </HStack>
         </CvModalForm>

--- a/src/app/(minCV)/_components/arbeidsforhold/ArbeidsforholdModal.jsx
+++ b/src/app/(minCV)/_components/arbeidsforhold/ArbeidsforholdModal.jsx
@@ -1,4 +1,4 @@
-import { Checkbox, CheckboxGroup, HStack, Textarea, TextField, VStack } from "@navikt/ds-react";
+import { BodyShort, Checkbox, CheckboxGroup, HStack, Textarea, TextField, VStack } from "@navikt/ds-react";
 import styles from "@/app/page.module.css";
 import { useEffect, useState } from "react";
 import { Typeahead } from "@/app/(minCV)/_components/typeahead/Typeahead";
@@ -22,7 +22,13 @@ export function ArbeidsforholdModal({ modalÅpen, toggleModal, gjeldendeElement,
 
     const [stillingstittelError, setStillingstittelError] = useState(false);
     const [startdatoError, setStartdatoError] = useState(false);
+    const [startdatoIsAfterError, setStartdatoIsAfterError] = useState(false);
+    const [startdatoIsValidDateError, setStartdatoIsValidDateError] = useState(false);
     const [sluttdatoError, setSluttdatoError] = useState(false);
+    const [sluttdatoIsAfterError, setSluttdatoIsAfterError] = useState(false);
+    const [sluttdatoIsValidDateError, setSluttdatoIsValidDateError] = useState(false);
+
+    const [isLagre, setIsLagre] = useState(false);
 
     useEffect(() => {
         const oppdaterArbeidsforhold = (arbeidsforhold) => {
@@ -44,13 +50,22 @@ export function ArbeidsforholdModal({ modalÅpen, toggleModal, gjeldendeElement,
     }, [gjeldendeElement]);
 
     const lagre = async () => {
+        setIsLagre(true);
         const erPågående = pågår.includes("true");
 
         if (!stillingstittel) setStillingstittelError(true);
         if (!startdato) setStartdatoError(true);
         if (!erPågående && !sluttdato) setSluttdatoError(true);
 
-        if (stillingstittel && startdato && (sluttdato || erPågående)) {
+        if (
+            stillingstittel &&
+            startdato &&
+            (sluttdato || erPågående) &&
+            !startdatoIsAfterError &&
+            !startdatoIsValidDateError &&
+            !sluttdatoIsAfterError &&
+            !sluttdatoIsValidDateError
+        ) {
             await lagreElement({
                 ...gjeldendeElement,
                 employer: arbeidsgiver,
@@ -136,20 +151,42 @@ export function ArbeidsforholdModal({ modalÅpen, toggleModal, gjeldendeElement,
                 <Datovelger
                     valgtDato={startdato}
                     oppdaterDato={setStartdato}
-                    label="Fra dato"
+                    label={
+                        <VStack>
+                            <BodyShort weight="semibold">Fra dato</BodyShort>
+                            <BodyShort className={styles.mandatoryColor}>Må fylles ut</BodyShort>
+                        </VStack>
+                    }
                     obligatorisk
-                    error={startdatoError}
-                    setError={setStartdatoError}
+                    isEmptyError={startdatoError}
+                    setIsEmptyError={setStartdatoError}
+                    isAfterError={startdatoIsAfterError}
+                    setIsAfterError={setStartdatoIsAfterError}
+                    isValidDateError={startdatoIsValidDateError}
+                    setIsValidDateError={setStartdatoIsValidDateError}
+                    isLagre={isLagre}
+                    setIsLagre={setIsLagre}
                 />
 
                 {!pågår.includes("true") && (
                     <Datovelger
                         valgtDato={sluttdato}
                         oppdaterDato={setSluttdato}
-                        label="Til dato"
+                        label={
+                            <VStack>
+                                <BodyShort weight="semibold">Til dato</BodyShort>
+                                <BodyShort className={styles.mandatoryColor}>Må fylles ut</BodyShort>
+                            </VStack>
+                        }
                         obligatorisk
-                        error={sluttdatoError}
-                        setError={setSluttdatoError}
+                        isEmptyError={sluttdatoError}
+                        setIsEmptyError={setSluttdatoError}
+                        isAfterError={sluttdatoIsAfterError}
+                        setIsAfterError={setSluttdatoIsAfterError}
+                        isValidDateError={sluttdatoIsValidDateError}
+                        setIsValidDateError={setSluttdatoIsValidDateError}
+                        isLagre={isLagre}
+                        setIsLagre={setIsLagre}
                     />
                 )}
             </HStack>

--- a/src/app/(minCV)/_components/arbeidsforhold/ArbeidsforholdModal.jsx
+++ b/src/app/(minCV)/_components/arbeidsforhold/ArbeidsforholdModal.jsx
@@ -28,7 +28,8 @@ export function ArbeidsforholdModal({ modalÅpen, toggleModal, gjeldendeElement,
     const [sluttdatoIsAfterError, setSluttdatoIsAfterError] = useState(false);
     const [sluttdatoIsValidDateError, setSluttdatoIsValidDateError] = useState(false);
 
-    const [isLagre, setIsLagre] = useState(false);
+    const [isLagreStartdato, setIsLagreStartdato] = useState(false);
+    const [isLagreSluttdato, setIsLagreSluttdato] = useState(false);
 
     useEffect(() => {
         const oppdaterArbeidsforhold = (arbeidsforhold) => {
@@ -50,7 +51,9 @@ export function ArbeidsforholdModal({ modalÅpen, toggleModal, gjeldendeElement,
     }, [gjeldendeElement]);
 
     const lagre = async () => {
-        setIsLagre(true);
+        setIsLagreStartdato(true);
+        setIsLagreSluttdato(true);
+
         const erPågående = pågår.includes("true");
 
         if (!stillingstittel) setStillingstittelError(true);
@@ -164,8 +167,8 @@ export function ArbeidsforholdModal({ modalÅpen, toggleModal, gjeldendeElement,
                     setIsAfterError={setStartdatoIsAfterError}
                     isValidDateError={startdatoIsValidDateError}
                     setIsValidDateError={setStartdatoIsValidDateError}
-                    isLagre={isLagre}
-                    setIsLagre={setIsLagre}
+                    isLagre={isLagreStartdato}
+                    setIsLagre={setIsLagreStartdato}
                 />
 
                 {!pågår.includes("true") && (
@@ -185,8 +188,8 @@ export function ArbeidsforholdModal({ modalÅpen, toggleModal, gjeldendeElement,
                         setIsAfterError={setSluttdatoIsAfterError}
                         isValidDateError={sluttdatoIsValidDateError}
                         setIsValidDateError={setSluttdatoIsValidDateError}
-                        isLagre={isLagre}
-                        setIsLagre={setIsLagre}
+                        isLagre={isLagreSluttdato}
+                        setIsLagre={setIsLagreSluttdato}
                     />
                 )}
             </HStack>

--- a/src/app/(minCV)/_components/datovelger/Datovelger.jsx
+++ b/src/app/(minCV)/_components/datovelger/Datovelger.jsx
@@ -8,8 +8,14 @@ export function Datovelger({
     fremtid = false,
     obligatorisk = false,
     className,
-    error,
-    setError,
+    isEmptyError,
+    setIsEmptyError,
+    isAfterError,
+    setIsAfterError,
+    isValidDateError,
+    setIsValidDateError,
+    isLagre,
+    setIsLagre,
 }) {
     useEffect(() => {
         const oppdaterDatepickerDato = (dato) => setSelected(dato);
@@ -27,11 +33,20 @@ export function Datovelger({
         toDate: hentDatoMedÅrsforskjell(fremtid ? 25 : 0),
         onDateChange: (val) => {
             oppdaterDato(val);
-            setError(false);
+            setIsEmptyError(false);
+            setIsValidDateError(false);
+            setIsAfterError(false);
+            setIsLagre(false);
         },
         onValidate: (val) => {
+            if (val.isAfter) {
+                setIsAfterError(true);
+            }
             if (!val.isEmpty) {
-                setError(!val.isValidDate);
+                setIsValidDateError(!val.isValidDate);
+            }
+            if (obligatorisk && val.isEmpty) {
+                setIsEmptyError(true);
             }
         },
     });
@@ -43,9 +58,12 @@ export function Datovelger({
                     <DatePicker.Input
                         {...inputProps}
                         label={label}
-                        description={obligatorisk ? "Må fylles ut" : undefined}
                         placeholder="dd.mm.yy"
-                        error={error && "Dato er ikke gyldig"}
+                        error={
+                            (isLagre && isAfterError && "Dato er frem i tid") ||
+                            (isLagre && isValidDateError && "Dato er ikke gyldig") ||
+                            (isLagre && isEmptyError && "Dato må fylles ut")
+                        }
                     />
                 </DatePicker>
             </HStack>

--- a/src/app/(minCV)/_components/kurs/KursModal.jsx
+++ b/src/app/(minCV)/_components/kurs/KursModal.jsx
@@ -15,6 +15,10 @@ export default function KursModal({ modalÅpen, toggleModal, gjeldendeElement, l
     const [kursnavnError, setKursnavnError] = useState(false);
     const [kursDatoError, setKursDatoError] = useState(false);
     const [lengdeError, setLengdeError] = useState(false);
+    const [isAfterError, setIsAfterError] = useState(false);
+    const [isValidDateError, setIsValidDateError] = useState(false);
+
+    const [isLagre, setIsLagre] = useState(false);
 
     useEffect(() => {
         const oppdaterKurs = (kurs) => {
@@ -28,10 +32,17 @@ export default function KursModal({ modalÅpen, toggleModal, gjeldendeElement, l
     }, [gjeldendeElement]);
 
     const lagre = async () => {
+        setIsLagre(true);
         if (!kursnavn) setKursnavnError(true);
         if (tidsenhet && tidsenhet !== "UKJENT" && !lengde) setLengdeError(true);
 
-        if (kursnavn && !kursDatoError && (tidsenhet && tidsenhet !== "UKJENT" ? lengde : true)) {
+        if (
+            kursnavn &&
+            !kursDatoError &&
+            (tidsenhet && tidsenhet !== "UKJENT" ? lengde : true) &&
+            !isAfterError &&
+            !isValidDateError
+        ) {
             await lagreElement({
                 title: kursnavn,
                 issuer: utsteder,
@@ -75,8 +86,14 @@ export default function KursModal({ modalÅpen, toggleModal, gjeldendeElement, l
                 oppdaterDato={setKursDato}
                 label="Fullført"
                 className={styles.mb6}
-                error={kursDatoError}
-                setError={setKursDatoError}
+                isEmptyError={kursDatoError}
+                setIsEmptyError={setKursDatoError}
+                isAfterError={isAfterError}
+                setIsAfterError={setIsAfterError}
+                isValidDateError={isValidDateError}
+                setIsValidDateError={setIsValidDateError}
+                isLagre={isLagre}
+                setIsLagre={setIsLagre}
             />
             <HStack gap="8">
                 <VStack>

--- a/src/app/(minCV)/_components/offentligeGodkjenninger/OffentligeGodkjenningerModal.jsx
+++ b/src/app/(minCV)/_components/offentligeGodkjenninger/OffentligeGodkjenningerModal.jsx
@@ -24,7 +24,13 @@ export default function OffentligeGodkjenningerModal({
     );
     const [valgtGodkjenningError, setValgtGodkjenningError] = useState(false);
     const [godkjenningFraDatoError, setGodkjenningFraDatoError] = useState(false);
+    const [fraDatoIsAfterError, setFraDatoIsAfterError] = useState(false);
+    const [fraDatoIsValidDateError, setFraDatoIsValidDateError] = useState(false);
     const [godkjenningTilDatoError, setGodkjenningTilDatoError] = useState(false);
+    const [tilDatoIsAfterError, setTilDatoIsAfterError] = useState(false);
+    const [tilDatoIsValidDateError, setTilDatoIsValidDateError] = useState(false);
+
+    const [isLagre, setIsLagre] = useState(false);
 
     useEffect(() => {
         const oppdaterGodkjenning = (godkjenning) => {
@@ -37,10 +43,20 @@ export default function OffentligeGodkjenningerModal({
     }, [gjeldendeElement]);
 
     const lagre = () => {
+        setIsLagre(true);
         if (!valgtGodkjenning || valgtGodkjenning.length === 0) setValgtGodkjenningError(true);
         if (!godkjenningFraDato) setGodkjenningFraDatoError(true);
 
-        if (valgtGodkjenning && valgtGodkjenning.length !== 0 && godkjenningFraDato && !godkjenningTilDatoError) {
+        if (
+            valgtGodkjenning &&
+            valgtGodkjenning.length !== 0 &&
+            godkjenningFraDato &&
+            !fraDatoIsAfterError &&
+            !fraDatoIsValidDateError &&
+            !godkjenningTilDatoError &&
+            !tilDatoIsAfterError &&
+            !tilDatoIsValidDateError
+        ) {
             lagreElement({
                 title: valgtGodkjenning.title,
                 conceptId: valgtGodkjenning.conceptId,
@@ -97,16 +113,29 @@ export default function OffentligeGodkjenningerModal({
                             <BodyShort className={styles.mandatoryColor}>Må fylles ut</BodyShort>
                         </HStack>
                     }
-                    error={godkjenningFraDatoError}
-                    setError={setGodkjenningFraDatoError}
+                    obligatorisk
+                    isEmptyError={godkjenningFraDatoError}
+                    setIsEmptyError={setGodkjenningFraDatoError}
+                    isAfterError={fraDatoIsAfterError}
+                    setIsAfterError={setFraDatoIsAfterError}
+                    isValidDateError={fraDatoIsValidDateError}
+                    setIsValidDateError={setFraDatoIsValidDateError}
+                    isLagre={isLagre}
+                    setIsLagre={setIsLagre}
                 />
                 <Datovelger
                     valgtDato={godkjenningTilDato}
                     oppdaterDato={setGodkjenningTilDato}
                     label="Utløper"
                     fremtid
-                    error={godkjenningTilDatoError}
-                    setError={setGodkjenningTilDatoError}
+                    isEmptyError={godkjenningTilDatoError}
+                    setIsEmptyError={setGodkjenningTilDatoError}
+                    isAfterError={tilDatoIsAfterError}
+                    setIsAfterError={setTilDatoIsAfterError}
+                    isValidDateError={tilDatoIsValidDateError}
+                    setIsValidDateError={setTilDatoIsValidDateError}
+                    isLagre={isLagre}
+                    setIsLagre={setIsLagre}
                 />
             </HStack>
         </CvModalForm>

--- a/src/app/(minCV)/_components/offentligeGodkjenninger/OffentligeGodkjenningerModal.jsx
+++ b/src/app/(minCV)/_components/offentligeGodkjenninger/OffentligeGodkjenningerModal.jsx
@@ -30,7 +30,8 @@ export default function OffentligeGodkjenningerModal({
     const [tilDatoIsAfterError, setTilDatoIsAfterError] = useState(false);
     const [tilDatoIsValidDateError, setTilDatoIsValidDateError] = useState(false);
 
-    const [isLagre, setIsLagre] = useState(false);
+    const [isLagreFraDato, setIsLagreFraDato] = useState(false);
+    const [isLagreTilDato, setIsLagreTilDato] = useState(false);
 
     useEffect(() => {
         const oppdaterGodkjenning = (godkjenning) => {
@@ -43,7 +44,9 @@ export default function OffentligeGodkjenningerModal({
     }, [gjeldendeElement]);
 
     const lagre = () => {
-        setIsLagre(true);
+        setIsLagreFraDato(true);
+        setIsLagreTilDato(true);
+
         if (!valgtGodkjenning || valgtGodkjenning.length === 0) setValgtGodkjenningError(true);
         if (!godkjenningFraDato) setGodkjenningFraDatoError(true);
 
@@ -120,8 +123,8 @@ export default function OffentligeGodkjenningerModal({
                     setIsAfterError={setFraDatoIsAfterError}
                     isValidDateError={fraDatoIsValidDateError}
                     setIsValidDateError={setFraDatoIsValidDateError}
-                    isLagre={isLagre}
-                    setIsLagre={setIsLagre}
+                    isLagre={isLagreFraDato}
+                    setIsLagre={setIsLagreFraDato}
                 />
                 <Datovelger
                     valgtDato={godkjenningTilDato}
@@ -134,8 +137,8 @@ export default function OffentligeGodkjenningerModal({
                     setIsAfterError={setTilDatoIsAfterError}
                     isValidDateError={tilDatoIsValidDateError}
                     setIsValidDateError={setTilDatoIsValidDateError}
-                    isLagre={isLagre}
-                    setIsLagre={setIsLagre}
+                    isLagre={isLagreTilDato}
+                    setIsLagre={setIsLagreTilDato}
                 />
             </HStack>
         </CvModalForm>

--- a/src/app/(minCV)/_components/utdanninger/UtdanningModal.jsx
+++ b/src/app/(minCV)/_components/utdanninger/UtdanningModal.jsx
@@ -1,4 +1,4 @@
-import { BodyShort, Checkbox, CheckboxGroup, HStack, Select, Textarea, TextField } from "@navikt/ds-react";
+import { BodyShort, Checkbox, CheckboxGroup, HStack, Select, Textarea, TextField, VStack } from "@navikt/ds-react";
 import styles from "@/app/page.module.css";
 import { UtdanningsnivåEnum } from "@/app/_common/enums/cvEnums";
 import { useEffect, useState } from "react";
@@ -13,9 +13,16 @@ export function UtdanningModal({ modalÅpen, toggleModal, gjeldendeElement, lagr
     const [startdato, setStartdato] = useState(null);
     const [sluttdato, setSluttdato] = useState(null);
     const [pågår, setPågår] = useState([]);
+
     const [utdanningsnivaError, setUtdanningsnivaError] = useState(false);
     const [startdatoError, setStartdatoError] = useState(false);
+    const [startdatoIsAfterError, setStartdatoIsAfterError] = useState(false);
+    const [startdatoIsValidDateError, setStartdatoIsValidDateError] = useState(false);
     const [sluttdatoError, setSluttdatoError] = useState(false);
+    const [sluttdatoIsAfterError, setSluttdatoIsAfterError] = useState(false);
+    const [sluttdatoIsValidDateError, setSluttdatoIsValidDateError] = useState(false);
+
+    const [isLagre, setIsLagre] = useState(false);
 
     useEffect(() => {
         const oppdaterUtdanning = (utdanning) => {
@@ -32,13 +39,22 @@ export function UtdanningModal({ modalÅpen, toggleModal, gjeldendeElement, lagr
     }, [gjeldendeElement]);
 
     const lagre = () => {
+        setIsLagre(true);
         const erPågående = pågår.includes("true");
 
         if (!utdanningsnivå) setUtdanningsnivaError(true);
         if (!startdato) setStartdatoError(true);
         if (!erPågående && !sluttdato) setSluttdatoError(true);
 
-        if (utdanningsnivå && startdato && (sluttdato || erPågående)) {
+        if (
+            utdanningsnivå &&
+            startdato &&
+            (sluttdato || erPågående) &&
+            !startdatoIsAfterError &&
+            !startdatoIsValidDateError &&
+            !sluttdatoIsAfterError &&
+            !sluttdatoIsValidDateError
+        ) {
             lagreElement({
                 ...gjeldendeElement,
                 nuskode: utdanningsnivå,
@@ -114,20 +130,42 @@ export function UtdanningModal({ modalÅpen, toggleModal, gjeldendeElement, lagr
                 <Datovelger
                     valgtDato={startdato}
                     oppdaterDato={setStartdato}
-                    label="Fra dato"
+                    label={
+                        <VStack>
+                            <BodyShort weight="semibold">Til dato</BodyShort>
+                            <BodyShort className={styles.mandatoryColor}>Må fylles ut</BodyShort>
+                        </VStack>
+                    }
                     obligatorisk
-                    error={startdatoError}
-                    setError={setStartdatoError}
+                    isEmptyError={startdatoError}
+                    setIsEmptyError={setStartdatoError}
+                    isAfterError={startdatoIsAfterError}
+                    setIsAfterError={setStartdatoIsAfterError}
+                    isValidDateError={startdatoIsValidDateError}
+                    setIsValidDateError={setStartdatoIsValidDateError}
+                    isLagre={isLagre}
+                    setIsLagre={setIsLagre}
                 />
 
                 {!pågår.includes("true") && (
                     <Datovelger
                         valgtDato={sluttdato}
                         oppdaterDato={setSluttdato}
-                        label="Til dato"
+                        label={
+                            <VStack>
+                                <BodyShort weight="semibold">Fra dato</BodyShort>
+                                <BodyShort className={styles.mandatoryColor}>Må fylles ut</BodyShort>
+                            </VStack>
+                        }
                         obligatorisk
-                        error={sluttdatoError}
-                        setError={setSluttdatoError}
+                        isEmptyError={sluttdatoError}
+                        setIsEmptyError={setSluttdatoError}
+                        isAfterError={sluttdatoIsAfterError}
+                        setIsAfterError={setSluttdatoIsAfterError}
+                        isValidDateError={sluttdatoIsValidDateError}
+                        setIsValidDateError={setSluttdatoIsValidDateError}
+                        isLagre={isLagre}
+                        setIsLagre={setIsLagre}
                     />
                 )}
             </HStack>

--- a/src/app/(minCV)/_components/utdanninger/UtdanningModal.jsx
+++ b/src/app/(minCV)/_components/utdanninger/UtdanningModal.jsx
@@ -22,7 +22,8 @@ export function UtdanningModal({ modalÅpen, toggleModal, gjeldendeElement, lagr
     const [sluttdatoIsAfterError, setSluttdatoIsAfterError] = useState(false);
     const [sluttdatoIsValidDateError, setSluttdatoIsValidDateError] = useState(false);
 
-    const [isLagre, setIsLagre] = useState(false);
+    const [isLagreStartdato, setIsLagreStartdato] = useState(false);
+    const [isLagreSluttdato, setIsLagreSluttdato] = useState(false);
 
     useEffect(() => {
         const oppdaterUtdanning = (utdanning) => {
@@ -39,7 +40,9 @@ export function UtdanningModal({ modalÅpen, toggleModal, gjeldendeElement, lagr
     }, [gjeldendeElement]);
 
     const lagre = () => {
-        setIsLagre(true);
+        setIsLagreStartdato(true);
+        setIsLagreSluttdato(true);
+
         const erPågående = pågår.includes("true");
 
         if (!utdanningsnivå) setUtdanningsnivaError(true);
@@ -143,8 +146,8 @@ export function UtdanningModal({ modalÅpen, toggleModal, gjeldendeElement, lagr
                     setIsAfterError={setStartdatoIsAfterError}
                     isValidDateError={startdatoIsValidDateError}
                     setIsValidDateError={setStartdatoIsValidDateError}
-                    isLagre={isLagre}
-                    setIsLagre={setIsLagre}
+                    isLagre={isLagreStartdato}
+                    setIsLagre={setIsLagreStartdato}
                 />
 
                 {!pågår.includes("true") && (
@@ -164,8 +167,8 @@ export function UtdanningModal({ modalÅpen, toggleModal, gjeldendeElement, lagr
                         setIsAfterError={setSluttdatoIsAfterError}
                         isValidDateError={sluttdatoIsValidDateError}
                         setIsValidDateError={setSluttdatoIsValidDateError}
-                        isLagre={isLagre}
-                        setIsLagre={setIsLagre}
+                        isLagre={isLagreSluttdato}
+                        setIsLagre={setIsLagreSluttdato}
                     />
                 )}
             </HStack>

--- a/src/app/(minCV)/_components/utdanninger/UtdanningModal.jsx
+++ b/src/app/(minCV)/_components/utdanninger/UtdanningModal.jsx
@@ -132,7 +132,7 @@ export function UtdanningModal({ modalÅpen, toggleModal, gjeldendeElement, lagr
                     oppdaterDato={setStartdato}
                     label={
                         <VStack>
-                            <BodyShort weight="semibold">Til dato</BodyShort>
+                            <BodyShort weight="semibold">Fra dato</BodyShort>
                             <BodyShort className={styles.mandatoryColor}>Må fylles ut</BodyShort>
                         </VStack>
                     }
@@ -153,7 +153,7 @@ export function UtdanningModal({ modalÅpen, toggleModal, gjeldendeElement, lagr
                         oppdaterDato={setSluttdato}
                         label={
                             <VStack>
-                                <BodyShort weight="semibold">Fra dato</BodyShort>
+                                <BodyShort weight="semibold">Til dato</BodyShort>
                                 <BodyShort className={styles.mandatoryColor}>Må fylles ut</BodyShort>
                             </VStack>
                         }


### PR DESCRIPTION
Legger til flere feilmeldingstyper på Datovelger:

- Egen feilmelding når datofeltet er tomt
- Egen feilmelding når validering av datoen feiler
- Egen feilmelding når datoen er satt høyere enn tillatt
- Feilmeldinger fremkommer kun etter at bruker klikker Lagre

Feilmedingen jeg har satt for dato høyere enn tillatt "Dato er frem i tid" er jeg ikke fornøyd med, men usikker på hva vi bør sette her som er kort nok til at ikke datofeltet brekker med tilstøtende datofelt i flere sammenhenger. Så denne er foreløpig.