### PR TITLE
Refaktorer feilmeldinger for datovelger

### DIFF
--- a/src/app/(minCV)/_components/andreErfaringer/AndreErfaringerModal.jsx
+++ b/src/app/(minCV)/_components/andreErfaringer/AndreErfaringerModal.jsx
@@ -13,14 +13,8 @@ export function AndreErfaringerModal({ modalÅpen, toggleModal, gjeldendeElement
 
     const [rolleError, setRolleError] = useState(false);
     const [startdatoError, setStartdatoError] = useState(false);
-    const [startdatoIsAfterError, setStartdatoIsAfterError] = useState(false);
-    const [startdatoIsValidDateError, setStartdatoIsValidDateError] = useState(false);
     const [sluttdatoError, setSluttdatoError] = useState(false);
-    const [sluttdatoIsAfterError, setSluttdatoIsAfterError] = useState(false);
-    const [sluttdatoIsValidDateError, setSluttdatoIsValidDateError] = useState(false);
-
-    const [isLagreStartdato, setIsLagreStartdato] = useState(false);
-    const [isLagreSluttdato, setIsLagreSluttdato] = useState(false);
+    const [skalViseDatofeilmelding, setSkalviseDatofeilmelding] = useState(false);
 
     useEffect(() => {
         const oppdaterErfaring = (erfaring) => {
@@ -35,24 +29,14 @@ export function AndreErfaringerModal({ modalÅpen, toggleModal, gjeldendeElement
     }, [gjeldendeElement]);
 
     const lagre = () => {
-        setIsLagreStartdato(true);
-        setIsLagreSluttdato(true);
+        setSkalviseDatofeilmelding(true);
 
         const erPågående = pågår.includes("true");
 
         if (!rolle) setRolleError(true);
-        if (!startdato) setStartdatoError(true);
-        if (!erPågående && !sluttdato) setSluttdatoError(true);
+        if (startdatoError || (!erPågående && sluttdatoError)) return;
 
-        if (
-            rolle &&
-            startdato &&
-            (sluttdato || erPågående) &&
-            !startdatoIsAfterError &&
-            !startdatoIsValidDateError &&
-            !sluttdatoIsAfterError &&
-            !sluttdatoIsValidDateError
-        ) {
+        if (rolle && startdato && (sluttdato || erPågående)) {
             lagreElement({
                 ...gjeldendeElement,
                 role: rolle,
@@ -111,14 +95,9 @@ export function AndreErfaringerModal({ modalÅpen, toggleModal, gjeldendeElement
                         </VStack>
                     }
                     obligatorisk
-                    isEmptyError={startdatoError}
-                    setIsEmptyError={setStartdatoError}
-                    isAfterError={startdatoIsAfterError}
-                    setIsAfterError={setStartdatoIsAfterError}
-                    isValidDateError={startdatoIsValidDateError}
-                    setIsValidDateError={setStartdatoIsValidDateError}
-                    isLagre={isLagreStartdato}
-                    setIsLagre={setIsLagreStartdato}
+                    setError={setStartdatoError}
+                    skalViseFeilmelding={skalViseDatofeilmelding}
+                    setSkalViseFeilmelding={setSkalviseDatofeilmelding}
                 />
 
                 {!pågår.includes("true") && (
@@ -132,14 +111,9 @@ export function AndreErfaringerModal({ modalÅpen, toggleModal, gjeldendeElement
                             </VStack>
                         }
                         obligatorisk
-                        isEmptyError={sluttdatoError}
-                        setIsEmptyError={setSluttdatoError}
-                        isAfterError={sluttdatoIsAfterError}
-                        setIsAfterError={setSluttdatoIsAfterError}
-                        isValidDateError={sluttdatoIsValidDateError}
-                        setIsValidDateError={setSluttdatoIsValidDateError}
-                        isLagre={isLagreSluttdato}
-                        setIsLagre={setIsLagreSluttdato}
+                        setError={setSluttdatoError}
+                        skalViseFeilmelding={skalViseDatofeilmelding}
+                        setSkalViseFeilmelding={setSkalviseDatofeilmelding}
                     />
                 )}
             </HStack>

--- a/src/app/(minCV)/_components/andreGodkjenninger/AndreGodkjenningerModal.jsx
+++ b/src/app/(minCV)/_components/andreGodkjenninger/AndreGodkjenningerModal.jsx
@@ -24,14 +24,8 @@ export default function AndreGodkjenningerModal({
     );
     const [valgtGodkjenningError, setValgtGodkjenningError] = useState(false);
     const [godkjenningFraDatoError, setGodkjenningFraDatoError] = useState(false);
-    const [fraDatoIsAfterError, setFraDatoIsAfterError] = useState(false);
-    const [fraDatoIsValidDateError, setFraDatoIsValidDateError] = useState(false);
     const [godkjenningTilDatoError, setGodkjenningTilDatoError] = useState(false);
-    const [tilDatoIsAfterError, setTilDatoIsAfterError] = useState(false);
-    const [tilDatoIsValidDateError, setTilDatoIsValidDateError] = useState(false);
-
-    const [isLagreFraDato, setIsLagreFraDato] = useState(false);
-    const [isLagreTilDato, setIsLagreTilDato] = useState(false);
+    const [skalViseDatofeilmelding, setSkalviseDatofeilmelding] = useState(false);
 
     useEffect(() => {
         const oppdaterGodkjenning = (godkjenning) => {
@@ -44,22 +38,12 @@ export default function AndreGodkjenningerModal({
     }, [gjeldendeElement]);
 
     const lagre = () => {
-        setIsLagreFraDato(true);
-        setIsLagreTilDato(true);
+        setSkalviseDatofeilmelding(true);
 
         if (!valgtGodkjenning || valgtGodkjenning.length === 0) setValgtGodkjenningError(true);
-        if (!godkjenningFraDato) setGodkjenningFraDatoError(true);
+        if (godkjenningFraDatoError || godkjenningTilDatoError) return;
 
-        if (
-            valgtGodkjenning &&
-            valgtGodkjenning.length !== 0 &&
-            godkjenningFraDato &&
-            !fraDatoIsAfterError &&
-            !fraDatoIsValidDateError &&
-            !godkjenningTilDatoError &&
-            !tilDatoIsAfterError &&
-            !tilDatoIsValidDateError
-        ) {
+        if (valgtGodkjenning && valgtGodkjenning.length !== 0 && godkjenningFraDato) {
             lagreElement({
                 certificateName: valgtGodkjenning.title || valgtGodkjenning.certificateName,
                 conceptId: valgtGodkjenning.conceptId,
@@ -117,28 +101,18 @@ export default function AndreGodkjenningerModal({
                         </HStack>
                     }
                     obligatorisk
-                    isEmptyError={godkjenningFraDatoError}
-                    setIsEmptyError={setGodkjenningFraDatoError}
-                    isAfterError={fraDatoIsAfterError}
-                    setIsAfterError={setFraDatoIsAfterError}
-                    isValidDateError={fraDatoIsValidDateError}
-                    setIsValidDateError={setFraDatoIsValidDateError}
-                    isLagre={isLagreFraDato}
-                    setIsLagre={setIsLagreFraDato}
+                    setError={setGodkjenningFraDatoError}
+                    skalViseFeilmelding={skalViseDatofeilmelding}
+                    setSkalViseFeilmelding={setSkalviseDatofeilmelding}
                 />
                 <Datovelger
                     valgtDato={godkjenningTilDato}
                     oppdaterDato={setGodkjenningTilDato}
                     label="Utløper"
                     fremtid
-                    isEmptyError={godkjenningTilDatoError}
-                    setIsEmptyError={setGodkjenningTilDatoError}
-                    isAfterError={tilDatoIsAfterError}
-                    setIsAfterError={setTilDatoIsAfterError}
-                    isValidDateError={tilDatoIsValidDateError}
-                    setIsValidDateError={setTilDatoIsValidDateError}
-                    isLagre={isLagreTilDato}
-                    setIsLagre={setIsLagreTilDato}
+                    setError={setGodkjenningTilDatoError}
+                    skalViseFeilmelding={skalViseDatofeilmelding}
+                    setSkalViseFeilmelding={setSkalviseDatofeilmelding}
                 />
             </HStack>
         </CvModalForm>

--- a/src/app/(minCV)/_components/arbeidsforhold/ArbeidsforholdModal.jsx
+++ b/src/app/(minCV)/_components/arbeidsforhold/ArbeidsforholdModal.jsx
@@ -22,14 +22,8 @@ export function ArbeidsforholdModal({ modalÅpen, toggleModal, gjeldendeElement,
 
     const [stillingstittelError, setStillingstittelError] = useState(false);
     const [startdatoError, setStartdatoError] = useState(false);
-    const [startdatoIsAfterError, setStartdatoIsAfterError] = useState(false);
-    const [startdatoIsValidDateError, setStartdatoIsValidDateError] = useState(false);
     const [sluttdatoError, setSluttdatoError] = useState(false);
-    const [sluttdatoIsAfterError, setSluttdatoIsAfterError] = useState(false);
-    const [sluttdatoIsValidDateError, setSluttdatoIsValidDateError] = useState(false);
-
-    const [isLagreStartdato, setIsLagreStartdato] = useState(false);
-    const [isLagreSluttdato, setIsLagreSluttdato] = useState(false);
+    const [skalViseDatofeilmelding, setSkalviseDatofeilmelding] = useState(false);
 
     useEffect(() => {
         const oppdaterArbeidsforhold = (arbeidsforhold) => {
@@ -51,24 +45,14 @@ export function ArbeidsforholdModal({ modalÅpen, toggleModal, gjeldendeElement,
     }, [gjeldendeElement]);
 
     const lagre = async () => {
-        setIsLagreStartdato(true);
-        setIsLagreSluttdato(true);
+        setSkalviseDatofeilmelding(true);
 
         const erPågående = pågår.includes("true");
 
         if (!stillingstittel) setStillingstittelError(true);
-        if (!startdato) setStartdatoError(true);
-        if (!erPågående && !sluttdato) setSluttdatoError(true);
+        if (startdatoError || (!erPågående && sluttdatoError)) return;
 
-        if (
-            stillingstittel &&
-            startdato &&
-            (sluttdato || erPågående) &&
-            !startdatoIsAfterError &&
-            !startdatoIsValidDateError &&
-            !sluttdatoIsAfterError &&
-            !sluttdatoIsValidDateError
-        ) {
+        if (stillingstittel && startdato && (sluttdato || erPågående)) {
             await lagreElement({
                 ...gjeldendeElement,
                 employer: arbeidsgiver,
@@ -161,14 +145,9 @@ export function ArbeidsforholdModal({ modalÅpen, toggleModal, gjeldendeElement,
                         </VStack>
                     }
                     obligatorisk
-                    isEmptyError={startdatoError}
-                    setIsEmptyError={setStartdatoError}
-                    isAfterError={startdatoIsAfterError}
-                    setIsAfterError={setStartdatoIsAfterError}
-                    isValidDateError={startdatoIsValidDateError}
-                    setIsValidDateError={setStartdatoIsValidDateError}
-                    isLagre={isLagreStartdato}
-                    setIsLagre={setIsLagreStartdato}
+                    setError={setStartdatoError}
+                    skalViseFeilmelding={skalViseDatofeilmelding}
+                    setSkalViseFeilmelding={setSkalviseDatofeilmelding}
                 />
 
                 {!pågår.includes("true") && (
@@ -182,14 +161,9 @@ export function ArbeidsforholdModal({ modalÅpen, toggleModal, gjeldendeElement,
                             </VStack>
                         }
                         obligatorisk
-                        isEmptyError={sluttdatoError}
-                        setIsEmptyError={setSluttdatoError}
-                        isAfterError={sluttdatoIsAfterError}
-                        setIsAfterError={setSluttdatoIsAfterError}
-                        isValidDateError={sluttdatoIsValidDateError}
-                        setIsValidDateError={setSluttdatoIsValidDateError}
-                        isLagre={isLagreSluttdato}
-                        setIsLagre={setIsLagreSluttdato}
+                        setError={setSluttdatoError}
+                        skalViseFeilmelding={skalViseDatofeilmelding}
+                        setSkalViseFeilmelding={setSkalviseDatofeilmelding}
                     />
                 )}
             </HStack>

--- a/src/app/(minCV)/_components/forerkort/FørerkortModal.jsx
+++ b/src/app/(minCV)/_components/forerkort/FørerkortModal.jsx
@@ -16,12 +16,8 @@ export default function FørerkortModal({ modalÅpen, toggleModal, gjeldendeElem
     const [kreverDato, setKreverDato] = useState(!!gjeldendeElement?.acquiredDate);
     const [valgtForerkortError, setValgtForerkortError] = useState(false);
     const [gyldigFraError, setGyldigFraError] = useState(false);
-    const [gyldigFraIsAfterError, setGyldigFraIsAfterError] = useState(false);
-    const [gyldigFraIsValidDateError, setGyldigFraIsValidDateError] = useState(false);
     const [gyldigTilError, setGyldigTilError] = useState(false);
-    const [gyldigTilIsAfterError, setGyldigTilIsAfterError] = useState(false);
-    const [gyldigTilIsValidDateError, setGyldigTilIsValidDateError] = useState(false);
-    const [isLagre, setIsLagre] = useState(false);
+    const [skalViseDatofeilmelding, setSkalviseDatofeilmelding] = useState(false);
 
     const { gyldigeFørerkort } = førerkortData;
 
@@ -38,19 +34,9 @@ export default function FørerkortModal({ modalÅpen, toggleModal, gjeldendeElem
     };
 
     const lagre = async () => {
-        setIsLagre(true);
+        setSkalviseDatofeilmelding(true);
         if (!valgtFørerkort || valgtFørerkort.length === 0) setValgtForerkortError(true);
-        if (kreverDato && !gyldigFra) setGyldigFraError(true);
-        if (kreverDato && !gyldigTil) setGyldigTilError(true);
-
-        const datoFeil =
-            gyldigFraIsAfterError ||
-            gyldigFraIsValidDateError ||
-            gyldigTilError ||
-            gyldigTilIsAfterError ||
-            gyldigTilIsValidDateError;
-
-        if (kreverDato && datoFeil) return;
+        if (kreverDato && (gyldigTilError || gyldigFraError)) return;
 
         if (valgtFørerkort && valgtFørerkort.length !== 0 && (kreverDato ? gyldigFra && gyldigTil : true)) {
             lagreElement({
@@ -95,14 +81,9 @@ export default function FørerkortModal({ modalÅpen, toggleModal, gjeldendeElem
                             oppdaterDato={setGyldigFra}
                             label="Gyldig fra"
                             obligatorisk
-                            isEmptyError={gyldigFraError}
-                            setIsEmptyError={setGyldigFraError}
-                            isAfterError={gyldigFraIsAfterError}
-                            setIsAfterError={setGyldigFraIsAfterError}
-                            isValidDateError={gyldigFraIsValidDateError}
-                            setIsValidDateError={setGyldigFraIsValidDateError}
-                            isLagre={isLagre}
-                            setIsLagre={setIsLagre}
+                            setError={setGyldigFraError}
+                            skalViseFeilmelding={skalViseDatofeilmelding}
+                            setSkalViseFeilmelding={setSkalviseDatofeilmelding}
                         />
                         <Datovelger
                             valgtDato={gyldigTil}
@@ -110,14 +91,9 @@ export default function FørerkortModal({ modalÅpen, toggleModal, gjeldendeElem
                             label="Gyldig til"
                             obligatorisk
                             fremtid
-                            isEmptyError={gyldigTilError}
-                            setIsEmptyError={setGyldigTilError}
-                            isAfterError={gyldigTilIsAfterError}
-                            setIsAfterError={setGyldigTilIsAfterError}
-                            isValidDateError={gyldigTilIsValidDateError}
-                            setIsValidDateError={setGyldigTilIsValidDateError}
-                            isLagre={isLagre}
-                            setIsLagre={setIsLagre}
+                            setError={setGyldigTilError}
+                            skalViseFeilmelding={skalViseDatofeilmelding}
+                            setSkalViseFeilmelding={setSkalviseDatofeilmelding}
                         />
                     </HStack>
                 )}

--- a/src/app/(minCV)/_components/kurs/KursModal.jsx
+++ b/src/app/(minCV)/_components/kurs/KursModal.jsx
@@ -15,10 +15,7 @@ export default function KursModal({ modalÅpen, toggleModal, gjeldendeElement, l
     const [kursnavnError, setKursnavnError] = useState(false);
     const [kursDatoError, setKursDatoError] = useState(false);
     const [lengdeError, setLengdeError] = useState(false);
-    const [isAfterError, setIsAfterError] = useState(false);
-    const [isValidDateError, setIsValidDateError] = useState(false);
-
-    const [isLagre, setIsLagre] = useState(false);
+    const [skalViseDatofeilmelding, setSkalviseDatofeilmelding] = useState(false);
 
     useEffect(() => {
         const oppdaterKurs = (kurs) => {
@@ -32,17 +29,12 @@ export default function KursModal({ modalÅpen, toggleModal, gjeldendeElement, l
     }, [gjeldendeElement]);
 
     const lagre = async () => {
-        setIsLagre(true);
+        setSkalviseDatofeilmelding(true);
         if (!kursnavn) setKursnavnError(true);
         if (tidsenhet && tidsenhet !== "UKJENT" && !lengde) setLengdeError(true);
+        if (kursDatoError) return;
 
-        if (
-            kursnavn &&
-            !kursDatoError &&
-            (tidsenhet && tidsenhet !== "UKJENT" ? lengde : true) &&
-            !isAfterError &&
-            !isValidDateError
-        ) {
+        if (kursnavn && !kursDatoError && (tidsenhet && tidsenhet !== "UKJENT" ? lengde : true)) {
             await lagreElement({
                 title: kursnavn,
                 issuer: utsteder,
@@ -86,14 +78,9 @@ export default function KursModal({ modalÅpen, toggleModal, gjeldendeElement, l
                 oppdaterDato={setKursDato}
                 label="Fullført"
                 className={styles.mb6}
-                isEmptyError={kursDatoError}
-                setIsEmptyError={setKursDatoError}
-                isAfterError={isAfterError}
-                setIsAfterError={setIsAfterError}
-                isValidDateError={isValidDateError}
-                setIsValidDateError={setIsValidDateError}
-                isLagre={isLagre}
-                setIsLagre={setIsLagre}
+                setError={setKursDatoError}
+                skalViseFeilmelding={skalViseDatofeilmelding}
+                setSkalViseFeilmelding={setSkalviseDatofeilmelding}
             />
             <HStack gap="8">
                 <VStack>

--- a/src/app/(minCV)/_components/offentligeGodkjenninger/OffentligeGodkjenningerModal.jsx
+++ b/src/app/(minCV)/_components/offentligeGodkjenninger/OffentligeGodkjenningerModal.jsx
@@ -24,14 +24,8 @@ export default function OffentligeGodkjenningerModal({
     );
     const [valgtGodkjenningError, setValgtGodkjenningError] = useState(false);
     const [godkjenningFraDatoError, setGodkjenningFraDatoError] = useState(false);
-    const [fraDatoIsAfterError, setFraDatoIsAfterError] = useState(false);
-    const [fraDatoIsValidDateError, setFraDatoIsValidDateError] = useState(false);
     const [godkjenningTilDatoError, setGodkjenningTilDatoError] = useState(false);
-    const [tilDatoIsAfterError, setTilDatoIsAfterError] = useState(false);
-    const [tilDatoIsValidDateError, setTilDatoIsValidDateError] = useState(false);
-
-    const [isLagreFraDato, setIsLagreFraDato] = useState(false);
-    const [isLagreTilDato, setIsLagreTilDato] = useState(false);
+    const [skalViseDatofeilmelding, setSkalviseDatofeilmelding] = useState(false);
 
     useEffect(() => {
         const oppdaterGodkjenning = (godkjenning) => {
@@ -44,22 +38,12 @@ export default function OffentligeGodkjenningerModal({
     }, [gjeldendeElement]);
 
     const lagre = () => {
-        setIsLagreFraDato(true);
-        setIsLagreTilDato(true);
+        setSkalviseDatofeilmelding(true);
 
         if (!valgtGodkjenning || valgtGodkjenning.length === 0) setValgtGodkjenningError(true);
-        if (!godkjenningFraDato) setGodkjenningFraDatoError(true);
+        if (godkjenningFraDatoError || godkjenningTilDatoError) return;
 
-        if (
-            valgtGodkjenning &&
-            valgtGodkjenning.length !== 0 &&
-            godkjenningFraDato &&
-            !fraDatoIsAfterError &&
-            !fraDatoIsValidDateError &&
-            !godkjenningTilDatoError &&
-            !tilDatoIsAfterError &&
-            !tilDatoIsValidDateError
-        ) {
+        if (valgtGodkjenning && valgtGodkjenning.length !== 0 && godkjenningFraDato) {
             lagreElement({
                 title: valgtGodkjenning.title,
                 conceptId: valgtGodkjenning.conceptId,
@@ -117,28 +101,18 @@ export default function OffentligeGodkjenningerModal({
                         </HStack>
                     }
                     obligatorisk
-                    isEmptyError={godkjenningFraDatoError}
-                    setIsEmptyError={setGodkjenningFraDatoError}
-                    isAfterError={fraDatoIsAfterError}
-                    setIsAfterError={setFraDatoIsAfterError}
-                    isValidDateError={fraDatoIsValidDateError}
-                    setIsValidDateError={setFraDatoIsValidDateError}
-                    isLagre={isLagreFraDato}
-                    setIsLagre={setIsLagreFraDato}
+                    setError={setGodkjenningFraDatoError}
+                    skalViseFeilmelding={skalViseDatofeilmelding}
+                    setSkalViseFeilmelding={setSkalviseDatofeilmelding}
                 />
                 <Datovelger
                     valgtDato={godkjenningTilDato}
                     oppdaterDato={setGodkjenningTilDato}
                     label="Utløper"
                     fremtid
-                    isEmptyError={godkjenningTilDatoError}
-                    setIsEmptyError={setGodkjenningTilDatoError}
-                    isAfterError={tilDatoIsAfterError}
-                    setIsAfterError={setTilDatoIsAfterError}
-                    isValidDateError={tilDatoIsValidDateError}
-                    setIsValidDateError={setTilDatoIsValidDateError}
-                    isLagre={isLagreTilDato}
-                    setIsLagre={setIsLagreTilDato}
+                    setError={setGodkjenningTilDatoError}
+                    skalViseFeilmelding={skalViseDatofeilmelding}
+                    setSkalViseFeilmelding={setSkalviseDatofeilmelding}
                 />
             </HStack>
         </CvModalForm>

--- a/src/app/(minCV)/_components/utdanninger/UtdanningModal.jsx
+++ b/src/app/(minCV)/_components/utdanninger/UtdanningModal.jsx
@@ -16,14 +16,8 @@ export function UtdanningModal({ modalÅpen, toggleModal, gjeldendeElement, lagr
 
     const [utdanningsnivaError, setUtdanningsnivaError] = useState(false);
     const [startdatoError, setStartdatoError] = useState(false);
-    const [startdatoIsAfterError, setStartdatoIsAfterError] = useState(false);
-    const [startdatoIsValidDateError, setStartdatoIsValidDateError] = useState(false);
     const [sluttdatoError, setSluttdatoError] = useState(false);
-    const [sluttdatoIsAfterError, setSluttdatoIsAfterError] = useState(false);
-    const [sluttdatoIsValidDateError, setSluttdatoIsValidDateError] = useState(false);
-
-    const [isLagreStartdato, setIsLagreStartdato] = useState(false);
-    const [isLagreSluttdato, setIsLagreSluttdato] = useState(false);
+    const [skalViseDatofeilmelding, setSkalviseDatofeilmelding] = useState(false);
 
     useEffect(() => {
         const oppdaterUtdanning = (utdanning) => {
@@ -40,24 +34,14 @@ export function UtdanningModal({ modalÅpen, toggleModal, gjeldendeElement, lagr
     }, [gjeldendeElement]);
 
     const lagre = () => {
-        setIsLagreStartdato(true);
-        setIsLagreSluttdato(true);
+        setSkalviseDatofeilmelding(true);
 
         const erPågående = pågår.includes("true");
 
         if (!utdanningsnivå) setUtdanningsnivaError(true);
-        if (!startdato) setStartdatoError(true);
-        if (!erPågående && !sluttdato) setSluttdatoError(true);
+        if (startdatoError || (!erPågående && sluttdatoError)) return;
 
-        if (
-            utdanningsnivå &&
-            startdato &&
-            (sluttdato || erPågående) &&
-            !startdatoIsAfterError &&
-            !startdatoIsValidDateError &&
-            !sluttdatoIsAfterError &&
-            !sluttdatoIsValidDateError
-        ) {
+        if (utdanningsnivå && startdato && (sluttdato || erPågående)) {
             lagreElement({
                 ...gjeldendeElement,
                 nuskode: utdanningsnivå,
@@ -140,14 +124,9 @@ export function UtdanningModal({ modalÅpen, toggleModal, gjeldendeElement, lagr
                         </VStack>
                     }
                     obligatorisk
-                    isEmptyError={startdatoError}
-                    setIsEmptyError={setStartdatoError}
-                    isAfterError={startdatoIsAfterError}
-                    setIsAfterError={setStartdatoIsAfterError}
-                    isValidDateError={startdatoIsValidDateError}
-                    setIsValidDateError={setStartdatoIsValidDateError}
-                    isLagre={isLagreStartdato}
-                    setIsLagre={setIsLagreStartdato}
+                    setError={setStartdatoError}
+                    skalViseFeilmelding={skalViseDatofeilmelding}
+                    setSkalViseFeilmelding={setSkalviseDatofeilmelding}
                 />
 
                 {!pågår.includes("true") && (
@@ -161,14 +140,9 @@ export function UtdanningModal({ modalÅpen, toggleModal, gjeldendeElement, lagr
                             </VStack>
                         }
                         obligatorisk
-                        isEmptyError={sluttdatoError}
-                        setIsEmptyError={setSluttdatoError}
-                        isAfterError={sluttdatoIsAfterError}
-                        setIsAfterError={setSluttdatoIsAfterError}
-                        isValidDateError={sluttdatoIsValidDateError}
-                        setIsValidDateError={setSluttdatoIsValidDateError}
-                        isLagre={isLagreSluttdato}
-                        setIsLagre={setIsLagreSluttdato}
+                        setError={setSluttdatoError}
+                        skalViseFeilmelding={skalViseDatofeilmelding}
+                        setSkalViseFeilmelding={setSkalviseDatofeilmelding}
                     />
                 )}
             </HStack>


### PR DESCRIPTION
Forslag til refaktorering av datovelger-feilmeldingene slik at Datovelgeren selv i hovedsak er ansvarlig for feilmeldingene. 

I "originalen" var det veldig mange ekstra state-varialber som ikke ble brukt i komponenten, men bare sendt videre til datovelger. Desuten er det bare én feilmelding som vises for et datofelt om gangen, så erroren burde heller være én enum enn flere booleans som må vurderes for å minske muligheten for bugs. 