### PR TITLE
Skjul valgfri-felter som er tomme i visningen

### DIFF
--- a/src/app/(minCV)/_components/andreErfaringer/AndreErfaringer.jsx
+++ b/src/app/(minCV)/_components/andreErfaringer/AndreErfaringer.jsx
@@ -80,10 +80,12 @@ export default function AndreErfaringer() {
                                                     <FormSummary.Value>{`${formatterDato(erfaring.fromDate)} - ${formatterDato(erfaring.toDate)}`}</FormSummary.Value>
                                                 </FormSummary.Answer>
 
-                                                <FormSummary.Answer>
-                                                    <FormSummary.Label>Beskrivelse</FormSummary.Label>
-                                                    <FormSummary.Value>{erfaring.description}</FormSummary.Value>
-                                                </FormSummary.Answer>
+                                                {erfaring.description && (
+                                                    <FormSummary.Answer>
+                                                        <FormSummary.Label>Beskrivelse</FormSummary.Label>
+                                                        <FormSummary.Value>{erfaring.description}</FormSummary.Value>
+                                                    </FormSummary.Answer>
+                                                )}
                                             </FormSummary.Answers>
                                         </FormSummary>
                                         <HStack justify="space-between" className={styles.mb6}>

--- a/src/app/(minCV)/_components/andreGodkjenninger/AndreGodkjenninger.jsx
+++ b/src/app/(minCV)/_components/andreGodkjenninger/AndreGodkjenninger.jsx
@@ -76,10 +76,12 @@ export default function AndreGodkjenninger() {
                                             </FormSummary.Heading>
                                         </FormSummary.Header>
                                         <FormSummary.Answers aria-labelledby={summaryHeadingId}>
-                                            <FormSummary.Answer>
-                                                <FormSummary.Label>Utsteder</FormSummary.Label>
-                                                <FormSummary.Value>{godkjenning.issuer}</FormSummary.Value>
-                                            </FormSummary.Answer>
+                                            {godkjenning.issuer && (
+                                                <FormSummary.Answer>
+                                                    <FormSummary.Label>Utsteder</FormSummary.Label>
+                                                    <FormSummary.Value>{godkjenning.issuer}</FormSummary.Value>
+                                                </FormSummary.Answer>
+                                            )}
                                             <FormSummary.Answer>
                                                 <FormSummary.Label>{`Gyldig${godkjenning.toDate ? "" : " fra"}`}</FormSummary.Label>
                                                 <FormSummary.Value>

--- a/src/app/(minCV)/_components/jobbonsker/Jobbonsker.jsx
+++ b/src/app/(minCV)/_components/jobbonsker/Jobbonsker.jsx
@@ -113,30 +113,44 @@ export default function Jobbonsker() {
                                         {formatterListeAvObjekterTilTekst(jobbønsker.locations, "location")}
                                     </BodyLong>
                                 </dd>
-                                <dt>
-                                    <BodyLong weight="semibold">Heltid eller deltid</BodyLong>
-                                </dt>
-                                <dd>
-                                    <BodyLong spacing>
-                                        {jobbønsker.workLoadTypes.map((e) => OmfangEnum[e]).join(", ")}
-                                    </BodyLong>
-                                </dd>
-                                <dt>
-                                    <BodyLong weight="semibold">Arbeidstider</BodyLong>
-                                </dt>
-                                <dd>
-                                    <BodyLong spacing>
-                                        {jobbønsker.workScheduleTypes.map((e) => ArbeidstidEnum[e]).join(", ")}
-                                    </BodyLong>
-                                </dd>
-                                <dt>
-                                    <BodyLong weight="semibold">Ansettelsesform</BodyLong>
-                                </dt>
-                                <dd>
-                                    <BodyLong spacing>
-                                        {jobbønsker.occupationTypes.map((e) => AnsettelsesformEnum[e]).join(", ")}
-                                    </BodyLong>
-                                </dd>
+                                {jobbønsker.workLoadTypes && jobbønsker.workLoadTypes.length > 0 && (
+                                    <>
+                                        <dt>
+                                            <BodyLong weight="semibold">Heltid eller deltid</BodyLong>
+                                        </dt>
+                                        <dd>
+                                            <BodyLong spacing>
+                                                {jobbønsker.workLoadTypes.map((e) => OmfangEnum[e]).join(", ")}
+                                            </BodyLong>
+                                        </dd>
+                                    </>
+                                )}
+                                {jobbønsker.workScheduleTypes && jobbønsker.workScheduleTypes.length > 0 && (
+                                    <>
+                                        <dt>
+                                            <BodyLong weight="semibold">Arbeidstider</BodyLong>
+                                        </dt>
+                                        <dd>
+                                            <BodyLong spacing>
+                                                {jobbønsker.workScheduleTypes.map((e) => ArbeidstidEnum[e]).join(", ")}
+                                            </BodyLong>
+                                        </dd>
+                                    </>
+                                )}
+                                {jobbønsker.occupationTypes && jobbønsker.occupationTypes.length > 0 && (
+                                    <>
+                                        <dt>
+                                            <BodyLong weight="semibold">Ansettelsesform</BodyLong>
+                                        </dt>
+                                        <dd>
+                                            <BodyLong spacing>
+                                                {jobbønsker.occupationTypes
+                                                    .map((e) => AnsettelsesformEnum[e])
+                                                    .join(", ")}
+                                            </BodyLong>
+                                        </dd>
+                                    </>
+                                )}
                                 <dt>
                                     <BodyLong weight="semibold">Oppstart</BodyLong>
                                 </dt>

--- a/src/app/(minCV)/_components/kurs/Kurs.jsx
+++ b/src/app/(minCV)/_components/kurs/Kurs.jsx
@@ -78,18 +78,18 @@ export default function Kurs() {
                                             </FormSummary.Heading>
                                         </FormSummary.Header>
                                         <FormSummary.Answers aria-labelledby={summaryHeadingId}>
-                                            {k.issuer && (
+                                            <FormSummary.Answer>
+                                                <FormSummary.Label>Utsteder</FormSummary.Label>
+                                                <FormSummary.Value>{k.issuer || "Ikke oppgitt"}</FormSummary.Value>
+                                            </FormSummary.Answer>
+                                            {k.date && (
                                                 <FormSummary.Answer>
-                                                    <FormSummary.Label>Utsteder</FormSummary.Label>
-                                                    <FormSummary.Value>{k.issuer}</FormSummary.Value>
+                                                    <FormSummary.Label>Fullført</FormSummary.Label>
+                                                    <FormSummary.Value>
+                                                        {formatterFullDatoMedFallback(k.date)}
+                                                    </FormSummary.Value>
                                                 </FormSummary.Answer>
                                             )}
-                                            <FormSummary.Answer>
-                                                <FormSummary.Label>Fullført</FormSummary.Label>
-                                                <FormSummary.Value>
-                                                    {formatterFullDatoMedFallback(k.date)}
-                                                </FormSummary.Value>
-                                            </FormSummary.Answer>
                                             {k.durationUnit !== "UKJENT" && (
                                                 <FormSummary.Answer>
                                                     <FormSummary.Label>Kursvarighet</FormSummary.Label>

--- a/src/app/(minCV)/_components/offentligeGodkjenninger/OffentligeGodkjenninger.jsx
+++ b/src/app/(minCV)/_components/offentligeGodkjenninger/OffentligeGodkjenninger.jsx
@@ -77,10 +77,12 @@ export default function OffentligeGodkjenninger() {
                                             </FormSummary.Heading>
                                         </FormSummary.Header>
                                         <FormSummary.Answers aria-labelledby={summaryHeadingId}>
-                                            <FormSummary.Answer>
-                                                <FormSummary.Label>Utsteder</FormSummary.Label>
-                                                <FormSummary.Value>{godkjenning.issuer}</FormSummary.Value>
-                                            </FormSummary.Answer>
+                                            {godkjenning.issuer && (
+                                                <FormSummary.Answer>
+                                                    <FormSummary.Label>Utsteder</FormSummary.Label>
+                                                    <FormSummary.Value>{godkjenning.issuer}</FormSummary.Value>
+                                                </FormSummary.Answer>
+                                            )}
                                             <FormSummary.Answer>
                                                 <FormSummary.Label>{`Gyldig${godkjenning.toDate ? "" : " fra"}`}</FormSummary.Label>
                                                 <FormSummary.Value>

--- a/src/app/(minCV)/_components/utdanninger/UtdanningModal.jsx
+++ b/src/app/(minCV)/_components/utdanninger/UtdanningModal.jsx
@@ -119,7 +119,7 @@ export function UtdanningModal({ modalÅpen, toggleModal, gjeldendeElement, lagr
                 className={styles.mb6}
                 error={errors?.nuskode}
                 onChange={(e) => {
-                    nusKode(e.target.value);
+                    setNusKode(e.target.value);
                 }}
                 onBlur={revalidate}
             >

--- a/src/app/(minCV)/_components/utdanninger/Utdanninger.jsx
+++ b/src/app/(minCV)/_components/utdanninger/Utdanninger.jsx
@@ -76,15 +76,19 @@ export default function Utdanninger() {
                                         </FormSummary.Header>
 
                                         <FormSummary.Answers aria-labelledby={summaryHeadingId}>
-                                            <FormSummary.Answer>
-                                                <FormSummary.Label>Grad og utdanningsretning</FormSummary.Label>
-                                                <FormSummary.Value>{utdanning.field}</FormSummary.Value>
-                                            </FormSummary.Answer>
+                                            {utdanning.field && (
+                                                <FormSummary.Answer>
+                                                    <FormSummary.Label>Grad og utdanningsretning</FormSummary.Label>
+                                                    <FormSummary.Value>{utdanning.field}</FormSummary.Value>
+                                                </FormSummary.Answer>
+                                            )}
 
-                                            <FormSummary.Answer>
-                                                <FormSummary.Label>Skole/studiested</FormSummary.Label>
-                                                <FormSummary.Value>{utdanning.institution}</FormSummary.Value>
-                                            </FormSummary.Answer>
+                                            {utdanning.institution && (
+                                                <FormSummary.Answer>
+                                                    <FormSummary.Label>Skole/studiested</FormSummary.Label>
+                                                    <FormSummary.Value>{utdanning.institution}</FormSummary.Value>
+                                                </FormSummary.Answer>
+                                            )}
 
                                             <FormSummary.Answer>
                                                 <FormSummary.Label>Start- og sluttdato</FormSummary.Label>
@@ -94,13 +98,14 @@ export default function Utdanninger() {
                                                 </FormSummary.Value>
                                             </FormSummary.Answer>
 
-                                            <FormSummary.Answer>
-                                                <FormSummary.Label>Beskrivelse</FormSummary.Label>
-                                                <FormSummary.Value>
-                                                    {utdanning.description &&
-                                                        parse(utdanning.description.replace(/\n/g, "<br>"))}
-                                                </FormSummary.Value>
-                                            </FormSummary.Answer>
+                                            {utdanning.description && (
+                                                <FormSummary.Answer>
+                                                    <FormSummary.Label>Beskrivelse</FormSummary.Label>
+                                                    <FormSummary.Value>
+                                                        {parse(utdanning.description.replace(/\n/g, "<br>"))}
+                                                    </FormSummary.Value>
+                                                </FormSummary.Answer>
+                                            )}
                                         </FormSummary.Answers>
                                     </FormSummary>
                                     <HStack justify="space-between" className={styles.mb12}>


### PR DESCRIPTION
Som diskutert på Slack vil Kurs vise "Ikke oppgitt" for utsteder for å hindre at det blir en tom boks. 

Har ikke gjort arbeidserfaring, fordi vi må avklare med design hvordan vi skal håndtere det der. 