### PR TITLE
Legg til hotjarlenke

### DIFF
--- a/src/app/(minCV)/_components/MinCVPage.jsx
+++ b/src/app/(minCV)/_components/MinCVPage.jsx
@@ -24,6 +24,7 @@ import { LastNedCv } from "@/app/(minCV)/_components/lastNedCv/LastNedCv";
 import Forhandsvisning from "@/app/(minCV)/_components/forhandsvisning/Forhandsvisning";
 import ApplicationProvider from "@/app/_common/contexts/ApplicationContext";
 import { useCv } from "@/app/_common/hooks/swr/useCv";
+import { HotjarWrapper } from "@/app/_common/components/HotjarWrapper";
 import styles from "../../page.module.css";
 
 export default function MinCVPage() {
@@ -58,6 +59,7 @@ export default function MinCVPage() {
                                             <Kurs />
                                             <Sammendrag />
                                             <DelingAvCV />
+                                            <HotjarWrapper />
                                         </VStack>
                                     </HStack>
                                 </Box>
@@ -92,6 +94,7 @@ export default function MinCVPage() {
                         <Kurs />
                         <Sammendrag />
                         <DelingAvCV />
+                        <HotjarWrapper />
                         <HStack justify="center" style={{ padding: "4rem 0 4rem 0" }}>
                             <VStack gap="4">
                                 <Button

--- a/src/app/_common/components/HotjarWrapper.jsx
+++ b/src/app/_common/components/HotjarWrapper.jsx
@@ -1,0 +1,22 @@
+import { BodyLong, Box, Heading, Link, VStack } from "@navikt/ds-react";
+import styles from "@/app/page.module.css";
+
+export function HotjarWrapper() {
+    return (
+        <Box padding="10" className={[styles.box, styles.hotjarWrapper]}>
+            <VStack gap="2">
+                <Heading level="2" size="medium" id="feedback-panel-title">
+                    Noe som mangler?
+                </Heading>
+
+                <BodyLong>Opplever du feil, eller fant du ikke det du ville registrere i CV-en?</BodyLong>
+
+                <BodyLong>
+                    <Link href="https://surveys.hotjar.com/256c1d1c-9b49-4a18-9d7b-28c7e570a174">
+                        Skriv en anonym tilbakemelding (åpner i en ny fane)
+                    </Link>
+                </BodyLong>
+            </VStack>
+        </Box>
+    );
+}

--- a/src/app/page.module.css
+++ b/src/app/page.module.css
@@ -653,3 +653,10 @@
 .sectionIcon {
     margin: -4.5rem 0 4rem 0;
 }
+
+.hotjarWrapper {
+    padding-bottom: 0;
+    padding-top: 0;
+    margin-top: var(--a-spacing-16) !important;
+    text-align: center;
+}


### PR DESCRIPTION
Litt improvisert design basert på det vi allerede har i gammel løsning: 

<img width="1265" alt="Screenshot 2024-11-25 at 15 45 05" src="https://github.com/user-attachments/assets/f9232c23-c252-439b-a0f1-479e86a2d49c">
