### PR TITLE
Legg feilmelding ved feil på typeahead inn i modalen

### DIFF
--- a/src/app/(minCV)/_components/typeahead/Typeahead.jsx
+++ b/src/app/(minCV)/_components/typeahead/Typeahead.jsx
@@ -1,5 +1,5 @@
 // eslint-disable-next-line camelcase
-import { BodyLong, Chips, UNSAFE_Combobox, VStack } from "@navikt/ds-react";
+import { Alert, BodyLong, Chips, UNSAFE_Combobox, VStack } from "@navikt/ds-react";
 import styles from "@/app/page.module.css";
 import { useTypeahead } from "@/app/_common/hooks/swr/useTypeahead";
 
@@ -28,7 +28,7 @@ export function Typeahead({
         alleredeValgte = [];
     }
 
-    const { typeaheadforslag, typeaheadLaster, oppdaterTypeahead, velgVerdi } = useTypeahead(
+    const { typeaheadforslag, typeaheadLaster, typeaheadHarFeil, oppdaterTypeahead, velgVerdi } = useTypeahead(
         type,
         visningsfelt,
         forhåndshentet,
@@ -38,6 +38,11 @@ export function Typeahead({
 
     return (
         <VStack className={className}>
+            {typeaheadHarFeil && (
+                <Alert aria-live="polite" role="alert" className={styles.mb3} variant="error">
+                    Det har oppstått en feil ved henting av forslag, vennligst prøv igjen.
+                </Alert>
+            )}
             <UNSAFE_Combobox
                 id={id}
                 label={label}
@@ -55,7 +60,7 @@ export function Typeahead({
                 error={error}
             />
             {multiselect && (
-                <VStack className={[styles.mt6]}>
+                <VStack className={styles.mt6}>
                     {alleredeValgte.length === 0 ? (
                         <BodyLong weight="regular" size="small" className={styles.mb3}>
                             {`Du har ikke lagt til noen ${multiselectText.toLowerCase()}`}

--- a/src/app/_common/hooks/swr/useTypeahead.js
+++ b/src/app/_common/hooks/swr/useTypeahead.js
@@ -2,27 +2,28 @@
 
 import useSWR from "swr";
 import { simpleApiRequest } from "@/app/_common/utils/fetchUtils";
-import { useContext, useMemo, useState } from "react";
+import { useMemo, useState } from "react";
 import { TypeaheadEnum } from "@/app/_common/enums/typeaheadEnums";
 import { debounce } from "@navikt/ds-react";
-import { ApplicationContext } from "@/app/_common/contexts/ApplicationContext";
 
 export const useTypeahead = (type, visningsfelt, forhåndshentet, alleredeValgte, oppdaterValg) => {
-    const { errorNotifikasjon } = useContext(ApplicationContext);
     const [typeaheadverdi, setTypeaheadverdi] = useState("");
     const [typeaheadforslag, setTypeaheadforslag] = useState([]);
     const [typeaheaddataFraBackend, setTypeaheaddataFraBackend] = useState([]);
     const debouncedSetTypeaheadverdi = useMemo(() => debounce(setTypeaheadverdi, 200), []);
+    const [harHattFeil, setHarHattFeil] = useState(false);
 
     const fetcher = async (url) => {
         const response = await simpleApiRequest(url, "GET", null, false);
 
         if (!response.ok) {
-            errorNotifikasjon("Det skjedde en feil ved henting av typeahead-data");
             const error = Error(`Det skjedde en feil ved henting av typeahead ${type}`);
             error.status = response.status;
+            setHarHattFeil(true);
             throw error;
         }
+
+        setHarHattFeil(false);
 
         const data = await response.json();
 
@@ -70,7 +71,7 @@ export const useTypeahead = (type, visningsfelt, forhåndshentet, alleredeValgte
     return {
         typeaheadforslag,
         typeaheadLaster: isLoading,
-        typeaheadHarFeil: error,
+        typeaheadHarFeil: error || (harHattFeil && isLoading),
         oppdaterTypeahead,
         velgVerdi,
     };


### PR DESCRIPTION
Fjerner også notifikasjonen som kom opp i dette tilfellet, da den alltid vil være delvis skjult av modal-backdropen. 

Blir seende sånn her ut etter input fra JV:
![Screenshot 2024-11-28 at 14 20 54](https://github.com/user-attachments/assets/b6edda28-0587-4d33-b05b-300a59331d99)
