### PR TITLE
Fjerner min-height ved landskapsmodus

### DIFF
--- a/src/app/page.module.css
+++ b/src/app/page.module.css
@@ -672,3 +672,9 @@
         padding-bottom: var(--a-spacing-3);
     }
 }
+
+@media (max-height: 630px) {
+    .modalBody {
+        min-height: 0;
+    }
+}


### PR DESCRIPTION
[Trello](https://trello.com/c/xHYRaQCw/64-134-elementer-nederst-i-modalene-vises-ikke-i-landskapsmodus-p%C3%A5-iphone)