### PR TITLE
Quickfix: Legger ikke til lokasjon dersom den mangler kode i jobbønsker

### DIFF
--- a/src/app/(minCV)/_components/jobbonsker/JobbonskerModal.jsx
+++ b/src/app/(minCV)/_components/jobbonsker/JobbonskerModal.jsx
@@ -77,7 +77,8 @@ export function JobbonskerModal({ modalÅpen, toggleModal, gjeldendeElement, lag
         const oppdaterteLokasjoner = [...lokasjoner];
         if (erValgt) {
             // Add styrk08 to code
-            oppdaterteLokasjoner.push({ ...lokasjon, code: lokasjon.styrk08 });
+            const nyLokasjon = { ...lokasjon, code: lokasjon.styrk08 };
+            if (nyLokasjon.code) oppdaterteLokasjoner.push({ ...lokasjon, code: lokasjon.styrk08 });
         } else {
             const eksisterendeIndex = oppdaterteLokasjoner.findIndex((e) => e.location === lokasjon.location);
             oppdaterteLokasjoner.splice(eksisterendeIndex, 1);


### PR DESCRIPTION
Vi har fått noen (39) tilfeller av at backend har lokasjon uten kode, som skaper problemer nedstrøms. Klarer ikke gjenskape eller finne feil i ontologien, så teorien er at det "noen ganger" skjer noe rart. 

Legger inn en "det skjer ingenting" dersom det er tilfellet. Kommer til å oppleves litt rart for brukerne det gjelder, men tenker det er såpass få at det er et greit kompromiss for å se om dette løser problemet. 