### PR TITLE
Henter kun Eures-data dersom bruker er innlogget

### DIFF
--- a/src/app/(minCV)/_components/delingAvCV/DelingAvCV.jsx
+++ b/src/app/(minCV)/_components/delingAvCV/DelingAvCV.jsx
@@ -94,7 +94,7 @@ function NavLogoIcon() {
 }
 
 export default function DelingAvCV() {
-    const { erVeileder } = useContext(ApplicationContext);
+    const { erVeileder, erInnlogget } = useContext(ApplicationContext);
     const { måBekrefteTidligereCv, personLaster } = usePerson();
     const { bekreftLaster, bekreftHarFeil, setBekreft } = useBekreftTidligereCv();
 
@@ -141,7 +141,7 @@ export default function DelingAvCV() {
                         </Button>
                     </div>
                 )}
-                {!erVeileder && <Euresdeling />}
+                {!erVeileder && erInnlogget && <Euresdeling />}
             </Box>
         </div>
     );


### PR DESCRIPTION
I dag kalles Eures selv på "skeleton"-siden før man logger inn, som fører til at man er uautorisert, og en del feil i loggene. Med denne så mountes ikke Eures-komponenten før man er innlogget. 